### PR TITLE
Reduce Docker image size (by ~85%)

### DIFF
--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -22,18 +22,19 @@ WORKDIR /app
 
 ENV NODE_ENV production
 ENV NEXT_TELEMETRY_DISABLED 1
+ENV PORT 3000
 
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 
-# Automatically leverage output traces to reduce image size 
+USER nextjs
+
+# Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing
 COPY --from=builder --chown=nextjs:nodejs /app/ ./
 
 USER nextjs
 
 EXPOSE 3000
-
-ENV PORT 3000
 
 CMD ["yarn", "start"]

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -31,10 +31,12 @@ USER nextjs
 
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing
-COPY --from=builder --chown=nextjs:nodejs /app/ ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone /app/next.config.js ./
 
-USER nextjs
+# Copy assets over as a backup for the CDN
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 
 EXPOSE 3000
 
-CMD ["yarn", "start"]
+CMD ["node", "server.js"]

--- a/next.config.js
+++ b/next.config.js
@@ -25,6 +25,7 @@ const nextConfig = {
     ],
   },
   compress: false,
+  output: 'standalone',
   poweredByHeader: false,
 };
 


### PR DESCRIPTION
The NextJS config wasn't setup to use only what's actually needed, so this PR is like one line to change that plus updating the Dockerfile to use it. Technically the static and public stuff isn't necessary, so you could make this even smaller if you really wanted to. Some import tuning and CommonJS target filtering would likely reduce this even more due to tree shaking. I'd prob update from Babel to Webpack at some point too which opens up further optimisation. Haven't tested this but it probably works.

For devs this won't change much as the standalone build doesn't impact the dev server. I did have a fiddle with distroless but it's not worth the annoyance of setting up users when there's no `nonroot` image for nodejs.

In build tests, this PR cuts the 1.56GB image down to 210-260MB depending on assets.