### PR TITLE
Remember last selected server on market pages

### DIFF
--- a/hooks/useSettings.ts
+++ b/hooks/useSettings.ts
@@ -4,6 +4,7 @@ import { Language } from '../types/universalis/lang';
 
 interface Settings {
   mogboard_server: string;
+  mogboard_last_selected_server: string;
   mogboard_language: Language;
   mogboard_timezone: string;
   mogboard_leftnav: 'on' | 'off';
@@ -30,6 +31,7 @@ export default function useSettings(): [
 ] {
   const keys: (keyof Settings)[] = [
     'mogboard_server',
+    'mogboard_last_selected_server',
     'mogboard_language',
     'mogboard_timezone',
     'mogboard_leftnav',

--- a/pages/market/[itemId].tsx
+++ b/pages/market/[itemId].tsx
@@ -91,11 +91,7 @@ const Market: NextPage<MarketProps> = ({
   };
 
   // Create state for selected server
-  const [selectedServer, setSelectedServer] = useState<
-    | { type: 'region'; region: string }
-    | { type: 'dc'; dc: DataCenter }
-    | { type: 'world'; world: World }
-  >(() => {
+  const [selectedServer, setSelectedServer] = useState<Server>(() => {
     // Try to find the last selected server
     const last = findServer(lastSelectedServer);
     // Try to find the server from the URL


### PR DESCRIPTION
This changes the market pages to remember your last selected server. This should make navigation smoother and allow people to set arbitrary servers as a default for page loads.