### PR TITLE
Move as much data fetching as possible to the client

### DIFF
--- a/components/Home/HomeUserList/HomeUserList.tsx
+++ b/components/Home/HomeUserList/HomeUserList.tsx
@@ -1,6 +1,6 @@
 import { t, Trans } from '@lingui/macro';
 import Link from 'next/link';
-import { Suspense, useEffect, useState } from 'react';
+import { Suspense } from 'react';
 import ago from 's-ago';
 import { sprintf } from 'sprintf-js';
 import { getItem, getItemKind, getItemSearchCategories } from '../../../data/game';
@@ -10,6 +10,7 @@ import { DataCenter } from '../../../types/game/DataCenter';
 import { ItemSearchCategory } from '../../../types/game/ItemSearchCategory';
 import { UserList } from '../../../types/universalis/user';
 import GameItemIcon from '../../GameItemIcon/GameItemIcon';
+import useSWR from 'swr';
 
 interface HomeUserListProps {
   dcs: DataCenter[];
@@ -50,21 +51,15 @@ export default function HomeUserList({ dcs, list }: HomeUserListProps) {
 
   const itemIdsStr = list.items.length <= 1 ? `0,${list.items[0]}` : list.items.join();
 
-  const [marketNq, setMarketNq] = useState<any>(null);
-  useEffect(() => {
-    fetch(`${getBaseUrl()}/v2/${dc?.name || 'Chaos'}/${itemIdsStr}?listings=1&entries=0&hq=0`)
-      .then((res) => res.json())
-      .then(setMarketNq)
-      .catch(console.error);
-  }, [dc?.name, itemIdsStr]);
+  const { data: marketNq } = useSWR(
+    `${getBaseUrl()}/v2/${dc?.name || 'Chaos'}/${itemIdsStr}?listings=1&entries=0&hq=0`,
+    (url) => fetch(url).then((res) => res.json())
+  );
 
-  const [marketHq, setMarketHq] = useState<any>(null);
-  useEffect(() => {
-    fetch(`${getBaseUrl()}/v2/${dc?.name || 'Chaos'}/${itemIdsStr}?listings=1&entries=0&hq=1`)
-      .then((res) => res.json())
-      .then(setMarketHq)
-      .catch(console.error);
-  }, [dc?.name, itemIdsStr]);
+  const { data: marketHq } = useSWR(
+    `${getBaseUrl()}/v2/${dc?.name || 'Chaos'}/${itemIdsStr}?listings=1&entries=0&hq=1`,
+    (url) => fetch(url).then((res) => res.json())
+  );
 
   const itemSearchCategories = getItemSearchCategories(lang);
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "sharp": "^0.30.7",
     "simplebar-react": "^2.4.1",
     "sprintf-js": "^1.1.2",
+    "swr": "^2.0.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/pages/account/characters.tsx
+++ b/pages/account/characters.tsx
@@ -7,8 +7,7 @@ import { useReducer, useRef, useState } from 'react';
 import { sprintf } from 'sprintf-js';
 import AccountLayout from '../../components/AccountLayout/AccountLayout';
 import { usePopup } from '../../components/UniversalisLayout/components/Popup/Popup';
-import { acquireConn, releaseConn } from '../../db/connect';
-import { getUserAuthCode, getUserCharacters } from '../../db/user-character';
+import { Database } from '../../db';
 import useSettings from '../../hooks/useSettings';
 import { getServers } from '../../service/servers';
 import { DataCenter } from '../../types/game/DataCenter';
@@ -355,9 +354,8 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   let characters: Partial<UserCharacter>[] = [];
   let verification = '';
   if (session && session.user.id) {
-    const conn = await acquireConn();
     try {
-      characters = (await getUserCharacters(session.user.id, conn)).map((character) => {
+      characters = (await Database.getUserCharacters(session.user.id)).map((character) => {
         const x: Partial<UserCharacter> = character;
         delete x.id;
         delete x.userId;
@@ -365,11 +363,9 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
       });
     } catch (err) {
       console.error(err);
-    } finally {
-      await releaseConn(conn);
     }
 
-    verification = getUserAuthCode(session.user.id);
+    verification = Database.getUserAuthCode(session.user.id);
   }
 
   let dcs: DataCenter[] = [];

--- a/pages/account/lists.tsx
+++ b/pages/account/lists.tsx
@@ -8,8 +8,7 @@ import AccountLayout from '../../components/AccountLayout/AccountLayout';
 import GameIcon from '../../components/GameIcon/GameIcon';
 import { usePopup } from '../../components/UniversalisLayout/components/Popup/Popup';
 import { getItem, getItemKind, getItemSearchCategory } from '../../data/game';
-import { acquireConn, releaseConn } from '../../db/connect';
-import { getUserLists } from '../../db/user-list';
+import { Database } from '../../db';
 import useSettings from '../../hooks/useSettings';
 import { Item } from '../../types/game/Item';
 import { UserList } from '../../types/universalis/user';
@@ -201,13 +200,10 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
 
   let lists: UserList[] = [];
   if (session && session.user.id) {
-    const conn = await acquireConn();
     try {
-      lists = await getUserLists(session.user.id, conn);
+      lists = await Database.getUserLists(session.user.id);
     } catch (err) {
       console.error(err);
-    } finally {
-      await releaseConn(conn);
     }
   }
 

--- a/pages/api/web/characters/index.ts
+++ b/pages/api/web/characters/index.ts
@@ -1,0 +1,30 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { Database } from '../../../../db';
+import { authOptions } from '../../auth/[...nextauth]';
+import { unstable_getServerSession } from 'next-auth';
+import { createHandler, Get, Req, Res } from 'next-api-decorators';
+import { UserCharacter } from '../../../../types/universalis/user';
+
+class CharactersHandler {
+  @Get()
+  async getCharacters(@Req() req: NextApiRequest, @Res() res: NextApiResponse) {
+    const session = await unstable_getServerSession(req, res, authOptions);
+    if (!session || !session.user.id) {
+      return res.status(401).json({ message: 'You must be logged in to perform this action.' });
+    }
+
+    // Fetch the user's characters
+    const characters: UserCharacter[] = [];
+    try {
+      const userCharacters = await Database.getUserCharacters(session.user.id);
+      characters.push(...userCharacters);
+    } catch (err) {
+      console.error(err);
+      return res.status(500).json({ message: 'An error occurred.' });
+    }
+
+    return res.json(characters);
+  }
+}
+
+export default createHandler(CharactersHandler);

--- a/pages/api/web/verify-code/index.ts
+++ b/pages/api/web/verify-code/index.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { Database } from '../../../../db';
+import { authOptions } from '../../auth/[...nextauth]';
+import { unstable_getServerSession } from 'next-auth';
+import { createHandler, Get, Req, Res } from 'next-api-decorators';
+
+class VerifyCodeHandler {
+  @Get()
+  async getVerifyCode(@Req() req: NextApiRequest, @Res() res: NextApiResponse) {
+    const session = await unstable_getServerSession(req, res, authOptions);
+    if (!session || !session.user.id) {
+      return res.status(401).json({ message: 'You must be logged in to perform this action.' });
+    }
+
+    return res.json({ code: Database.getUserAuthCode(session.user.id) });
+  }
+}
+
+export default createHandler(VerifyCodeHandler);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,5 @@
-import type { GetServerSidePropsContext, NextPage } from 'next';
+import type { NextPage } from 'next';
 import Head from 'next/head';
-import { Cookies } from 'react-cookie';
 import HomeAction from '../components/Home/HomeAction/HomeAction';
 import HomeLoggedOut from '../components/Home/HomeLoggedOut/HomeLoggedOut';
 import HomeNavbar from '../components/Home/HomeNavbar/HomeNavBar';
@@ -12,28 +11,18 @@ import UploadCountPanel from '../components/UploadCountPanel/UploadCountPanel';
 import WorldUploadCountsPanel from '../components/WorldUploadCountsPanel/WorldUploadCountsPanel';
 import { City } from '../types/game/City';
 import { UserList } from '../types/universalis/user';
-import { Database } from '../db';
-import { DataCenter } from '../types/game/DataCenter';
 import HomeUserList from '../components/Home/HomeUserList/HomeUserList';
 import { useState } from 'react';
 import { Trans } from '@lingui/macro';
-import { authOptions } from './api/auth/[...nextauth]';
 import { getItem } from '../data/game';
 import useSettings from '../hooks/useSettings';
 import { getServers } from '../service/servers';
 import { TaxRates } from '../types/universalis/TaxRates';
-import { unstable_getServerSession } from 'next-auth';
 import HomeLeastRecentlyUpdated from '../components/Home/HomeLeastRecentlyUpdated/HomeLeastRecentlyUpdated';
 import { getBaseUrl } from '../service/universalis';
 import useSWR from 'swr';
-
-interface HomeProps {
-  dcs: DataCenter[];
-  world: string;
-  server: string;
-  hasSession: boolean;
-  lists: UserList[];
-}
+import useSWRImmutable from 'swr/immutable';
+import { useSession } from 'next-auth/react';
 
 function sum(arr: number[], start: number, end: number) {
   return arr.slice(start, end).reduce((a, b) => a + b, 0);
@@ -63,11 +52,33 @@ function zeroTaxRates(): Record<City, number> {
   };
 }
 
-const Home: NextPage<HomeProps> = ({ dcs, world, server, hasSession, lists }: HomeProps) => {
+const Home: NextPage = () => {
+  const { status: sessionStatus } = useSession();
+
   const [settings] = useSettings();
   const lang = settings['mogboard_language'] || 'en';
 
   const [selectedList, setSelectedList] = useState<UserList | undefined>();
+
+  const world = settings['mogboard_server'] || 'Phoenix';
+
+  const { data: dcs } = useSWRImmutable('$servers', () =>
+    getServers().then((servers) =>
+      servers.dcs
+        .map((dc) => ({
+          name: dc.name,
+          region: dc.region,
+          worlds: dc.worlds.sort((a, b) => a.name.localeCompare(b.name)),
+        }))
+        .sort((a, b) => a.region.localeCompare(b.region))
+    )
+  );
+
+  const showHomeWorld = settings['mogboard_homeworld'] === 'yes';
+  const server = showHomeWorld
+    ? world
+    : (dcs ?? []).find((dc) => dc.worlds.some((w) => w.name.toLowerCase() === world.toLowerCase()))
+        ?.name || world;
 
   const { data: taxes } = useSWR<Record<City, number>>(
     `${getBaseUrl()}/tax-rates?world=${world}`,
@@ -120,6 +131,10 @@ const Home: NextPage<HomeProps> = ({ dcs, world, server, hasSession, lists }: Ho
         )
   );
 
+  const { data: lists } = useSWR<UserList[]>('/api/web/lists', (url) =>
+    fetch(url).then((res) => res.json())
+  );
+
   const title = 'Universalis';
   const description =
     'Final Fantasy XIV Online: Market Board aggregator. Find Prices, track Item History and create Price Alerts. Anywhere, anytime.';
@@ -135,10 +150,10 @@ const Home: NextPage<HomeProps> = ({ dcs, world, server, hasSession, lists }: Ho
 
       <div className="home">
         <HomeNavbar
-          hasSession={hasSession}
-          lists={lists.sort((a, b) => b.updated - a.updated)}
+          hasSession={sessionStatus === 'authenticated'}
+          lists={(lists ?? []).sort((a, b) => b.updated - a.updated)}
           onListSelected={(id) => {
-            const list = lists.find((list) => list.id === id);
+            const list = (lists ?? []).find((list) => list.id === id);
             if (!selectedList || list?.id !== selectedList?.id) {
               setSelectedList(list);
             } else if (list.id === selectedList.id) {
@@ -148,8 +163,8 @@ const Home: NextPage<HomeProps> = ({ dcs, world, server, hasSession, lists }: Ho
         />
         <div>
           <HomeNews />
-          {selectedList && <HomeUserList dcs={dcs} list={selectedList} />}
-          <LoggedOut hasSession={hasSession}>
+          {selectedList && <HomeUserList dcs={dcs ?? []} list={selectedList} />}
+          <LoggedOut hasSession={sessionStatus === 'authenticated'}>
             <HomeLoggedOut />
           </LoggedOut>
           <HomeLeastRecentlyUpdated
@@ -182,50 +197,5 @@ const Home: NextPage<HomeProps> = ({ dcs, world, server, hasSession, lists }: Ho
     </>
   );
 };
-
-export async function getServerSideProps(ctx: GetServerSidePropsContext) {
-  const cookies = new Cookies(ctx.req?.headers.cookie);
-  const world = cookies.get<string | undefined>('mogboard_server') || 'Phoenix';
-
-  let dcs: DataCenter[] = [];
-  try {
-    const servers = await getServers();
-    dcs = servers.dcs.map((dc) => ({
-      name: dc.name,
-      region: dc.region,
-      worlds: dc.worlds.sort((a, b) => a.name.localeCompare(b.name)),
-    }));
-  } catch (err) {
-    console.error(err);
-  }
-
-  const showHomeWorld = cookies.get<string | undefined>('mogboard_homeworld') === 'yes';
-  const server = showHomeWorld
-    ? world
-    : dcs.find((dc) => dc.worlds.some((w) => w.name.toLowerCase() === world.toLowerCase()))?.name ||
-      world;
-
-  const session = await unstable_getServerSession(ctx.req, ctx.res, authOptions);
-  const hasSession = !!session;
-
-  let lists: UserList[] = [];
-  if (session?.user?.id) {
-    try {
-      lists = await Database.getUserLists(session.user.id);
-    } catch (err) {
-      console.error(err);
-    }
-  }
-
-  return {
-    props: {
-      dcs,
-      world,
-      server,
-      hasSession,
-      lists,
-    },
-  };
-}
 
 export default Home;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -25,16 +25,12 @@ import { TaxRates } from '../types/universalis/TaxRates';
 import { unstable_getServerSession } from 'next-auth';
 import HomeLeastRecentlyUpdated from '../components/Home/HomeLeastRecentlyUpdated/HomeLeastRecentlyUpdated';
 import { getBaseUrl } from '../service/universalis';
+import useSWR from 'swr';
 
 interface HomeProps {
   dcs: DataCenter[];
   world: string;
   server: string;
-  taxes: Record<City, number>;
-  recent: number[];
-  leastRecents: { id: number; date: number; world: string }[];
-  dailyUploads: number[];
-  worldUploads: { world: string; count: number }[];
   hasSession: boolean;
   lists: UserList[];
 }
@@ -43,22 +39,86 @@ function sum(arr: number[], start: number, end: number) {
   return arr.slice(start, end).reduce((a, b) => a + b, 0);
 }
 
-const Home: NextPage<HomeProps> = ({
-  dcs,
-  world,
-  server,
-  taxes,
-  recent,
-  leastRecents,
-  dailyUploads,
-  worldUploads,
-  hasSession,
-  lists,
-}: HomeProps) => {
+function convertTaxRates(taxRates: TaxRates): Record<City, number> {
+  return {
+    [City.LimsaLominsa]: taxRates['Limsa Lominsa'] ?? 0,
+    [City.Gridania]: taxRates['Gridania'] ?? 0,
+    [City.Uldah]: taxRates["Ul'dah"] ?? 0,
+    [City.Ishgard]: taxRates['Ishgard'] ?? 0,
+    [City.Kugane]: taxRates['Kugane'] ?? 0,
+    [City.Crystarium]: taxRates['Crystarium'] ?? 0,
+    [City.OldSharlayan]: taxRates['Old Sharlayan'] ?? 0,
+  };
+}
+
+function zeroTaxRates(): Record<City, number> {
+  return {
+    [City.LimsaLominsa]: 0,
+    [City.Gridania]: 0,
+    [City.Uldah]: 0,
+    [City.Ishgard]: 0,
+    [City.Kugane]: 0,
+    [City.Crystarium]: 0,
+    [City.OldSharlayan]: 0,
+  };
+}
+
+const Home: NextPage<HomeProps> = ({ dcs, world, server, hasSession, lists }: HomeProps) => {
   const [settings] = useSettings();
   const lang = settings['mogboard_language'] || 'en';
 
   const [selectedList, setSelectedList] = useState<UserList | undefined>();
+
+  const { data: taxes } = useSWR<Record<City, number>>(
+    `${getBaseUrl()}/tax-rates?world=${world}`,
+    (url) =>
+      fetch(url)
+        .then((res) => res.json())
+        .then((res) => convertTaxRates(res))
+  );
+
+  const { data: dailyUploads } = useSWR<number[]>(
+    `${getBaseUrl()}/extra/stats/upload-history`,
+    (url) =>
+      fetch(url)
+        .then((res) => res.json())
+        .then((res) => res.uploadCountByDay)
+  );
+
+  const { data: recent } = useSWR<number[]>(`${getBaseUrl()}/extra/stats/recently-updated`, (url) =>
+    fetch(url)
+      .then((res) => res.json())
+      .then((res) => res.items.slice(0, 6))
+  );
+
+  const { data: worldUploads } = useSWR<{ world: string; count: number }[]>(
+    `${getBaseUrl()}/extra/stats/world-upload-counts`,
+    (url) =>
+      fetch(url)
+        .then((res) => res.json())
+        .then((res) =>
+          Object.keys(res).map((k) => ({
+            world: k,
+            count: res[k].count,
+          }))
+        )
+  );
+
+  const { data: leastRecents } = useSWR<{ id: number; date: number; world: string }[]>(
+    `${getBaseUrl()}/extra/stats/least-recently-updated?${
+      server.toLowerCase() === world.toLowerCase() ? 'world' : 'dcName'
+    }=${server}`,
+    (url) =>
+      fetch(url)
+        .then((res) => res.json())
+        .then((res) =>
+          res.items.slice(0, 20).map((entry: { [x: string]: string | number }) => ({
+            id: entry.itemID,
+            date: entry.lastUploadTime,
+            world: entry.worldName,
+          }))
+        )
+  );
 
   const title = 'Universalis';
   const description =
@@ -96,7 +156,10 @@ const Home: NextPage<HomeProps> = ({
             server={server}
             multiWorld={settings['mogboard_homeworld'] !== 'yes'}
             lang={lang}
-            leastRecents={leastRecents.map((entry) => ({ ...entry, date: new Date(entry.date) }))}
+            leastRecents={(leastRecents ?? []).map((entry) => ({
+              ...entry,
+              date: new Date(entry.date),
+            }))}
           />
         </div>
         <div>
@@ -104,10 +167,13 @@ const Home: NextPage<HomeProps> = ({
           <h4>
             <Trans>Recent Updates</Trans>
           </h4>
-          <RecentUpdatesPanel items={recent.map((itemId) => getItem(itemId, lang)!)} />
-          <TaxRatesPanel data={taxes} world={world} />
-          <WorldUploadCountsPanel data={worldUploads} world={world} />
-          <UploadCountPanel today={sum(dailyUploads, 0, 1)} week={sum(dailyUploads, 0, 7)} />
+          <RecentUpdatesPanel items={(recent ?? []).map((itemId) => getItem(itemId, lang)!)} />
+          <TaxRatesPanel data={taxes ?? zeroTaxRates()} world={world} />
+          <WorldUploadCountsPanel data={worldUploads ?? []} world={world} />
+          <UploadCountPanel
+            today={sum(dailyUploads ?? [], 0, 1)}
+            week={sum(dailyUploads ?? [], 0, 7)}
+          />
           <p className="mog-honorable" style={{ textAlign: 'center', marginTop: 5 }}>
             <Trans>Thank you!</Trans>
           </p>
@@ -116,30 +182,6 @@ const Home: NextPage<HomeProps> = ({
     </>
   );
 };
-
-function convertTaxRates(taxRates: TaxRates): Record<City, number> {
-  return {
-    [City.LimsaLominsa]: taxRates['Limsa Lominsa'] ?? 0,
-    [City.Gridania]: taxRates['Gridania'] ?? 0,
-    [City.Uldah]: taxRates["Ul'dah"] ?? 0,
-    [City.Ishgard]: taxRates['Ishgard'] ?? 0,
-    [City.Kugane]: taxRates['Kugane'] ?? 0,
-    [City.Crystarium]: taxRates['Crystarium'] ?? 0,
-    [City.OldSharlayan]: taxRates['Old Sharlayan'] ?? 0,
-  };
-}
-
-function zeroTaxRates(): Record<City, number> {
-  return {
-    [City.LimsaLominsa]: 0,
-    [City.Gridania]: 0,
-    [City.Uldah]: 0,
-    [City.Ishgard]: 0,
-    [City.Kugane]: 0,
-    [City.Crystarium]: 0,
-    [City.OldSharlayan]: 0,
-  };
-}
 
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   const cookies = new Cookies(ctx.req?.headers.cookie);
@@ -163,70 +205,6 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     : dcs.find((dc) => dc.worlds.some((w) => w.name.toLowerCase() === world.toLowerCase()))?.name ||
       world;
 
-  let taxes: Record<City, number>;
-  try {
-    const taxRates: TaxRates = await fetch(`${getBaseUrl()}/tax-rates?world=${world}`).then((res) =>
-      res.json()
-    );
-    taxes = convertTaxRates(taxRates);
-  } catch (err) {
-    console.error(err);
-    taxes = zeroTaxRates();
-  }
-
-  let recent: number[] = [];
-  try {
-    const recentlyUpdated = await fetch(`${getBaseUrl()}/extra/stats/recently-updated`).then(
-      (res) => res.json()
-    );
-    recent = recentlyUpdated.items.slice(0, 6);
-  } catch (err) {
-    console.error(err);
-  }
-
-  let leastRecents: number[] = [];
-  try {
-    const leastRecentlyUpdated = await fetch(
-      `${getBaseUrl()}/extra/stats/least-recently-updated?${
-        server.toLowerCase() === world.toLowerCase() ? 'world' : 'dcName'
-      }=${server}`
-    ).then((res) => res.json());
-    leastRecents = leastRecentlyUpdated.items
-      .slice(0, 20)
-      .map((entry: { [x: string]: string | number }) => ({
-        id: entry.itemID,
-        date: entry.lastUploadTime,
-        world: entry.worldName,
-      }));
-  } catch (err) {
-    console.error(err);
-  }
-
-  const dailyUploads: number[] = [];
-  try {
-    const uploadHistory = await fetch(`${getBaseUrl()}/extra/stats/upload-history`).then((res) =>
-      res.json()
-    );
-    dailyUploads.push(...uploadHistory.uploadCountByDay);
-  } catch (err) {
-    console.error(err);
-  }
-
-  const worldUploads: { world: string; count: number }[] = [];
-  try {
-    const worldUploadCounts: Record<string, { count: number; proportion: number }> = await fetch(
-      `${getBaseUrl()}/extra/stats/world-upload-counts`
-    ).then((res) => res.json());
-    worldUploads.push(
-      ...Object.keys(worldUploadCounts).map((k) => ({
-        world: k,
-        count: worldUploadCounts[k].count,
-      }))
-    );
-  } catch (err) {
-    console.error(err);
-  }
-
   const session = await unstable_getServerSession(ctx.req, ctx.res, authOptions);
   const hasSession = !!session;
 
@@ -244,11 +222,6 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
       dcs,
       world,
       server,
-      taxes,
-      recent,
-      leastRecents,
-      dailyUploads,
-      worldUploads,
       hasSession,
       lists,
     },

--- a/pages/list/[listId].tsx
+++ b/pages/list/[listId].tsx
@@ -19,6 +19,7 @@ import { DataCenter } from '../../types/game/DataCenter';
 import { Item } from '../../types/game/Item';
 import { UserList } from '../../types/universalis/user';
 import { authOptions } from '../api/auth/[...nextauth]';
+import useSWR from 'swr';
 
 interface ListProps {
   dcs: DataCenter[];
@@ -118,17 +119,10 @@ const List: NextPage<ListProps> = ({ dcs, list, reqIsOwner, ownerName }) => {
 
   const itemIds = list.items.length <= 1 ? `0,${list.items[0]}` : list.items.join();
 
-  const [market, setMarket] = useState<any>(null);
-  useEffect(() => {
-    if (stateList.items.length === 0 || market) {
-      return;
-    }
-
-    fetch(`${getBaseUrl()}/v2/${server}/${itemIds}?listings=5&entries=5`)
-      .then((res) => res.json())
-      .then(setMarket)
-      .catch(console.error);
-  }, [stateList.items, itemIds, market, server]);
+  const { data: market } = useSWR(
+    `${getBaseUrl()}/v2/${server}/${itemIds}?listings=5&entries=5`,
+    (url) => fetch(url).then((res) => res.json())
+  );
 
   const items = stateList.items.reduce<Record<number, Item>>((agg, next) => {
     const item = getItem(next, lang);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5328,6 +5328,13 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+swr@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-2.0.0.tgz#91d999359e2be92de1a41f6b6711d72be20ffdbd"
+  integrity sha512-IhUx5yPkX+Fut3h0SqZycnaNLXLXsb2ECFq0Y29cxnK7d8r7auY2JWNbCW3IX+EqXUg3rwNJFlhrw5Ye/b6k7w==
+  dependencies:
+    use-sync-external-store "^1.2.0"
+
 symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
@@ -5576,6 +5583,11 @@ use-sync-external-store@1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz"
   integrity sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==
+
+use-sync-external-store@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
 util-deprecate@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
This moves almost all data fetching to the client, with the exception of the list page and the market tables. The list page requires some database querying I haven't moved to the API yet, and the market pages need the tables pre-rendered for Google Sheets and Excel consumers.

This causes some UI jittering on loads, but I plan on adding some loading indicators later, to mitigate that.