### PR TITLE
Retry critical API calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "18.2.0",
     "react-icons": "^4.4.0",
+    "retry-as-promised": "^7.0.3",
     "s-ago": "^2.2.0",
     "sharp": "^0.30.7",
     "simplebar-react": "^2.4.1",

--- a/pages/market/[itemId].tsx
+++ b/pages/market/[itemId].tsx
@@ -21,7 +21,6 @@ import { Cookies } from 'react-cookie';
 import { World } from '../../types/game/World';
 import { getServers } from '../../service/servers';
 import { ParsedUrlQuery } from 'querystring';
-import { Connection } from 'mariadb';
 import MarketServerUpdateTimes from '../../components/Market/MarketServerUpdateTimes/MarketServerUpdateTimes';
 import MarketRegion from '../../components/Market/MarketRegion/MarketRegion';
 import MarketRegionUpdateTimes from '../../components/Market/MarketRegionUpdateTimes/MarketRegionUpdateTimes';

--- a/service/servers.ts
+++ b/service/servers.ts
@@ -3,6 +3,7 @@ import { DataCenter } from '../types/game/DataCenter';
 import { World } from '../types/game/World';
 import { cache } from './cache';
 import { getBaseUrl } from './universalis';
+import retry from 'retry-as-promised';
 
 export interface Servers {
   dcs: DataCenter[];
@@ -10,6 +11,15 @@ export interface Servers {
 }
 
 export async function getServers(): Promise<Servers> {
+  return retry(getServersInternal, {
+    max: 3,
+    timeout: 5000,
+    report: (message) => console.warn(message),
+    name: 'getServers',
+  });
+}
+
+async function getServersInternal(): Promise<Servers> {
   if (cache.servers && differenceInMinutes(cache.servers.cachedAt, new Date()) <= 5) {
     return cache.servers.value;
   }

--- a/service/timezones.ts
+++ b/service/timezones.ts
@@ -1,4 +1,5 @@
 import { differenceInMinutes } from 'date-fns';
+import retry from 'retry-as-promised';
 import { cache } from './cache';
 import { getBaseUrl } from './universalis';
 
@@ -9,6 +10,15 @@ export interface TimeZone {
 }
 
 export async function getTimeZones(): Promise<TimeZone[]> {
+  return retry(getTimeZonesInternal, {
+    max: 3,
+    timeout: 5000,
+    report: (message) => console.warn(message),
+    name: 'getTimeZones',
+  });
+}
+
+async function getTimeZonesInternal(): Promise<TimeZone[]> {
   if (cache.timezones && differenceInMinutes(cache.timezones.cachedAt, new Date()) <= 5) {
     return cache.timezones.value;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4949,6 +4949,11 @@ restore-cursor@^3.1.0:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
 
+retry-as-promised@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/retry-as-promised/-/retry-as-promised-7.0.3.tgz#ca3c13b15525a7bfbf0f56d2996f0e75649d068b"
+  integrity sha512-SEvMa4khHvpU/o6zgh7sK24qm6rxVgKnrSyzb5POeDvZx5N9Bf0s5sQsQ4Fl+HjRp0X+w2UzACGfUnXtx6cJ9Q==
+
 reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz"


### PR DESCRIPTION
The market page cannot load without server data, so at least one server must respond to server requests. I also added retries to timezones since that was easy.