### PR TITLE
Adjust retry policies and use market fallbacks

### DIFF
--- a/service/servers.ts
+++ b/service/servers.ts
@@ -5,6 +5,8 @@ import { cache } from './cache';
 import { getBaseUrl } from './universalis';
 import retry from 'retry-as-promised';
 
+const isDev = process.env['APP_ENV'] !== 'prod';
+
 export interface Servers {
   dcs: DataCenter[];
   worlds: World[];
@@ -12,9 +14,9 @@ export interface Servers {
 
 export async function getServers(): Promise<Servers> {
   return retry(getServersInternal, {
-    max: 3,
-    timeout: 5000,
-    report: (message) => console.warn(message),
+    max: 5,
+    backoffBase: 1000,
+    report: (message) => isDev && console.warn(message),
     name: 'getServers',
   });
 }

--- a/service/timezones.ts
+++ b/service/timezones.ts
@@ -3,6 +3,8 @@ import retry from 'retry-as-promised';
 import { cache } from './cache';
 import { getBaseUrl } from './universalis';
 
+const isDev = process.env['APP_ENV'] !== 'prod';
+
 export interface TimeZone {
   id: string;
   offset: number;
@@ -11,9 +13,9 @@ export interface TimeZone {
 
 export async function getTimeZones(): Promise<TimeZone[]> {
   return retry(getTimeZonesInternal, {
-    max: 3,
-    timeout: 5000,
-    report: (message) => console.warn(message),
+    max: 5,
+    backoffBase: 1000,
+    report: (message) => isDev && console.warn(message),
     name: 'getTimeZones',
   });
 }


### PR DESCRIPTION
* Only log requests in development
* Retry 5 times instead of 3
* Use a higher initial backoff delay
* Return fallback data for market requests instead of erroring