### PR TITLE
Improve alignment of region update times

### DIFF
--- a/styles/page_items.scss
+++ b/styles/page_items.scss
@@ -994,8 +994,7 @@
       }
 
       > div {
-        flex: 0 1 auto;
-        flex-grow: 1;
+        flex: 1 1;
         padding: 6px;
         text-align: center;
         font-size: 14px;


### PR DESCRIPTION
Slight change to flexbox settings to improve alignment of region update times.
Screenshots on Opera GX browser on a 2k monitor.

Original:
![image](https://user-images.githubusercontent.com/45836420/215616010-0c198fa6-893f-4af9-ba2a-1985fcb23ed4.png)

Fixed:
![image](https://user-images.githubusercontent.com/45836420/215616177-85313a51-b63e-4d13-8620-2a5e17cb57ad.png)

Notice columns are exactly aligned on center, particularly the FAERIE and GILGAMESH columns.
