### PR TITLE
Make market nav buttons smaller

### DIFF
--- a/components/Market/MarketNav/MarketNav.tsx
+++ b/components/Market/MarketNav/MarketNav.tsx
@@ -323,7 +323,7 @@ export default function MarketNav({
             rel="noopener noreferrer"
           >
             <button type="button" className="btn btn_gt">
-              <Trans>Show on Saddlebag Exchange</Trans>
+              <Trans>Saddlebag Exchange</Trans>
             </button>
           </a>
           <a
@@ -332,7 +332,7 @@ export default function MarketNav({
             rel="noopener noreferrer"
           >
             <button type="button" className="btn btn_gt">
-              <Trans>Show on GarlandTools</Trans>
+              <Trans>GarlandTools</Trans>
             </button>
           </a>
           <a
@@ -341,7 +341,7 @@ export default function MarketNav({
             rel="noopener noreferrer"
           >
             <button type="button" className="btn btn_gt">
-              <Trans>Show on Teamcraft</Trans>
+              <Trans>Teamcraft</Trans>
             </button>
           </a>
           <LoggedIn hasSession={hasSession}>


### PR DESCRIPTION
This is a partial fix for the buttons overlapping the item name for items with longer names. The real problem here is that the navbar has absolute positioning - this should really be rebuilt with a flexbox.