### PR TITLE
Add OCE server selector for non-OCE players

### DIFF
--- a/components/Market/MarketDataCenter/MarketDataCenter.tsx
+++ b/components/Market/MarketDataCenter/MarketDataCenter.tsx
@@ -10,6 +10,8 @@ import MarketAverages from '../MarketAverages/MarketAverages';
 import MarketCheapest from '../MarketCheapest/MarketCheapest';
 import MarketHistoryGraph from '../MarketHistoryGraph/MarketHistoryGraph';
 import MarketStackSizeHistogram from '../MarketStackSizeHistogram/MarketStackSizeHistogram';
+import { useDataCenterMarket } from '../../../hooks/market';
+import MarketWorld from '../MarketWorld/MarketWorld';
 
 interface MarketDataCenterProps {
   item: Item;
@@ -191,3 +193,14 @@ export default function MarketDataCenter({ item, dc, market, lang, open }: Marke
     </>
   );
 }
+
+export interface DynamicMarketDataCenterProps extends Omit<MarketDataCenterProps, 'market'> {}
+
+MarketDataCenter.Dynamic = function DynamicMarketDataCenter(props: DynamicMarketDataCenterProps) {
+  const { data: market } = useDataCenterMarket(props.dc.name, props.item.id);
+  if (!market) {
+    return <MarketWorld.Skeleton />;
+  }
+
+  return <MarketDataCenter {...props} market={market} />;
+};

--- a/components/Market/MarketRegion/MarketRegion.tsx
+++ b/components/Market/MarketRegion/MarketRegion.tsx
@@ -10,6 +10,10 @@ import MarketAverages from '../MarketAverages/MarketAverages';
 import MarketCheapest from '../MarketCheapest/MarketCheapest';
 import MarketHistoryGraph from '../MarketHistoryGraph/MarketHistoryGraph';
 import MarketStackSizeHistogram from '../MarketStackSizeHistogram/MarketStackSizeHistogram';
+import { useDataCenterMarkets } from '../../../hooks/market';
+import ErrorBoundary from '../../ErrorBoundary/ErrorBoundary';
+import { Suspense } from 'react';
+import MarketWorld from '../MarketWorld/MarketWorld';
 
 interface MarketRegionProps {
   item: Item;
@@ -218,3 +222,17 @@ export default function MarketRegion({
     </>
   );
 }
+
+export interface DynamicMarketRegionProps extends Omit<MarketRegionProps, 'dcMarkets'> {}
+
+MarketRegion.Dynamic = function DynamicMarketRegion(props: DynamicMarketRegionProps) {
+  const { data: markets } = useDataCenterMarkets(
+    props.dcs.map((dc) => dc.name),
+    props.item.id
+  );
+  if (!markets) {
+    return <MarketWorld.Skeleton />;
+  }
+
+  return <MarketRegion {...props} dcMarkets={markets} />;
+};

--- a/components/Market/MarketRegionUpdateTimes/MarketRegionUpdateTimes.tsx
+++ b/components/Market/MarketRegionUpdateTimes/MarketRegionUpdateTimes.tsx
@@ -5,12 +5,12 @@ import { DataCenter } from '../../../types/game/DataCenter';
 
 interface MarketRegionUpdateTimesProps {
   dcs: DataCenter[];
-  dcWorldUploadTimes: Record<string, Record<number, number>>;
+  worldUploadTimes: Record<number, number>;
 }
 
 export default function MarketRegionUpdateTimes({
   dcs,
-  dcWorldUploadTimes,
+  worldUploadTimes,
 }: MarketRegionUpdateTimesProps) {
   return (
     <div className="region_update_times">
@@ -21,8 +21,8 @@ export default function MarketRegionUpdateTimes({
               <h4>{world.name}</h4>
               <div>
                 <Suspense>
-                  {dcWorldUploadTimes[dc.name][world.id]
-                    ? ago(new Date(dcWorldUploadTimes[dc.name][world.id]))
+                  {worldUploadTimes[world.id]
+                    ? ago(new Date(worldUploadTimes[world.id]))
                     : t`No data`}
                 </Suspense>
               </div>

--- a/components/Market/MarketServerSelector/MarketServerSelector.tsx
+++ b/components/Market/MarketServerSelector/MarketServerSelector.tsx
@@ -3,6 +3,8 @@ import SimpleBar from 'simplebar-react';
 import { getServerRegionNameMap } from '../../../service/servers';
 import { DataCenter } from '../../../types/game/DataCenter';
 import { World } from '../../../types/game/World';
+import useDataCenters from '../../../hooks/useDataCenters';
+import ContentLoader from 'react-content-loader';
 
 type Server =
   | { type: 'region'; region: string }
@@ -11,12 +13,21 @@ type Server =
 
 interface MarketServerSelectorProps {
   region: string;
-  homeDc: DataCenter;
+  homeDc?: DataCenter;
   dcs: DataCenter[];
   homeWorldName?: string;
   selectedServer: Server;
   setSelectedServer: (server: Server) => void;
 }
+
+const regionNameMapping = getServerRegionNameMap({
+  europe: t`Europe`,
+  japan: t`Japan`,
+  america: t`America`,
+  oceania: t`Oceania`,
+  china: t`中国`,
+  korea: t`한국`,
+});
 
 export default function MarketServerSelector({
   region,
@@ -26,15 +37,6 @@ export default function MarketServerSelector({
   selectedServer,
   setSelectedServer,
 }: MarketServerSelectorProps) {
-  const regionNameMapping = getServerRegionNameMap({
-    europe: t`Europe`,
-    japan: t`Japan`,
-    america: t`America`,
-    oceania: t`Oceania`,
-    china: t`中国`,
-    korea: t`한국`,
-  });
-
   return (
     <SimpleBar style={{ width: '100%' }}>
       <div className="item_nav_servers">
@@ -59,7 +61,7 @@ export default function MarketServerSelector({
             <i className="xiv-CrossWorld cw-summary"></i> {dc.name}
           </button>
         ))}
-        {homeDc.worlds.map((world, i) => {
+        {(homeDc ?? dcs[0]).worlds.map((world, i) => {
           const homeWorld = world.name === homeWorldName;
           const icon = homeWorld ? 'xiv-ItemShard cw-home' : '';
           const className = homeWorld ? 'home-world' : '';
@@ -83,3 +85,53 @@ export default function MarketServerSelector({
     </SimpleBar>
   );
 }
+
+MarketServerSelector.Skeleton = function SkeletonServerSelector({
+  selectedServer,
+  setSelectedServer,
+  region,
+}: DynamicMarketServerSelectorProps) {
+  const worldPlaceholders = Array.from(Array(5).keys());
+  return (
+    <div className="item_nav_servers">
+      <button
+        type="button"
+        className={`btn-summary ${
+          selectedServer.type === 'region' && region === selectedServer.region ? 'open' : ''
+        }`}
+        onClick={() => setSelectedServer({ type: 'region', region })}
+      >
+        <i className="xiv-CrossWorld cw-summary"></i> {regionNameMapping.get(region)}
+      </button>
+      {worldPlaceholders.map((i) => {
+        const width = (1 / (i + 1)) * 10 + 50;
+        return (
+          <button key={i} type="button" className="btn-summary">
+            <ContentLoader
+              uniqueKey={`market-server-selector-skeleton-${region}-${i}`}
+              width={width}
+              height="10"
+              backgroundColor="#afb1b6"
+              foregroundColor="#ecebeb"
+            >
+              <rect rx="5" ry="5" width={width} height="10" />
+            </ContentLoader>
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export interface DynamicMarketServerSelectorProps extends Omit<MarketServerSelectorProps, 'dcs'> {}
+
+MarketServerSelector.Dynamic = function DynamicMarketServerSelector(
+  props: DynamicMarketServerSelectorProps
+) {
+  const { data: dcs } = useDataCenters(props.region);
+  if (!dcs) {
+    return <MarketServerSelector.Skeleton {...props} />;
+  }
+
+  return <MarketServerSelector {...props} dcs={dcs} />;
+};

--- a/components/Market/MarketServerSelector/MarketServerSelector.tsx
+++ b/components/Market/MarketServerSelector/MarketServerSelector.tsx
@@ -1,18 +1,12 @@
 import { t } from '@lingui/macro';
 import SimpleBar from 'simplebar-react';
-import { getServerRegionNameMap } from '../../../service/servers';
+import { Region, Server, getServerRegionNameMap } from '../../../service/servers';
 import { DataCenter } from '../../../types/game/DataCenter';
-import { World } from '../../../types/game/World';
 import useDataCenters from '../../../hooks/useDataCenters';
 import ContentLoader from 'react-content-loader';
 
-type Server =
-  | { type: 'region'; region: string }
-  | { type: 'dc'; dc: DataCenter }
-  | { type: 'world'; world: World };
-
 interface MarketServerSelectorProps {
-  region: string;
+  region: Region;
   homeDc?: DataCenter;
   dcs: DataCenter[];
   homeWorldName?: string;

--- a/components/Market/MarketWorld/MarketWorld.tsx
+++ b/components/Market/MarketWorld/MarketWorld.tsx
@@ -9,6 +9,8 @@ import SalesTable from '../../SalesTable/SalesTable';
 import MarketHistoryGraph from '../MarketHistoryGraph/MarketHistoryGraph';
 import MarketStackSizeHistogram from '../MarketStackSizeHistogram/MarketStackSizeHistogram';
 import NoMarketData from '../NoMarketData/NoMarketData';
+import { useWorldMarket } from '../../../hooks/market';
+import ContentLoader from 'react-content-loader';
 
 interface MarketWorldProps {
   item: Item;
@@ -88,3 +90,54 @@ export default function MarketWorld({ item, world, market, lang, open }: MarketW
     </>
   );
 }
+
+MarketWorld.Skeleton = function SkeletonMarketWorld() {
+  return (
+    <div className="tab-market-tables">
+      <div className="cw-table cw-prices">
+        <h4>
+          <Trans>PRICES</Trans>{' '}
+          <small>
+            <Suspense>
+              <Trans>Updated:</Trans>
+            </Suspense>
+          </small>
+        </h4>
+        <ContentLoader
+          uniqueKey="market-world-listings-table"
+          width="100%"
+          height="400"
+          backgroundColor="#282b34"
+          foregroundColor="#434856"
+        >
+          <rect rx="2" ry="2" width="100%" height="400" />
+        </ContentLoader>
+      </div>
+      <div className="cw-table cw-history">
+        <h4>
+          <Trans>HISTORY</Trans>
+        </h4>
+        <ContentLoader
+          uniqueKey="market-world-sales-table"
+          width="100%"
+          height="400"
+          backgroundColor="#282b34"
+          foregroundColor="#434856"
+        >
+          <rect rx="2" ry="2" width="100%" height="400" />
+        </ContentLoader>
+      </div>
+    </div>
+  );
+};
+
+export interface DynamicMarketWorldProps extends Omit<MarketWorldProps, 'market'> {}
+
+MarketWorld.Dynamic = function DynamicMarketWorld(props: DynamicMarketWorldProps) {
+  const { data: market } = useWorldMarket(props.world.id, props.item.id);
+  if (!market) {
+    return <MarketWorld.Skeleton />;
+  }
+
+  return <MarketWorld {...props} market={market} />;
+};

--- a/components/Spacing/Spacing.tsx
+++ b/components/Spacing/Spacing.tsx
@@ -1,0 +1,7 @@
+export interface SpacingProps {
+  size: number;
+}
+
+export default function Spacing({ size }: SpacingProps) {
+  return <div style={{ height: size }} />;
+}

--- a/components/UniversalisLayout/components/SettingsModal/SettingsModal.tsx
+++ b/components/UniversalisLayout/components/SettingsModal/SettingsModal.tsx
@@ -1,6 +1,5 @@
-import { t, Trans } from '@lingui/macro';
+import { Trans } from '@lingui/macro';
 import { useEffect, useState } from 'react';
-import { getServers, getServerRegionNameMap, Servers } from '../../../../service/servers';
 import { getTimeZones, TimeZone } from '../../../../service/timezones';
 import useClickOutside from '../../../../hooks/useClickOutside';
 import useSettings from '../../../../hooks/useSettings';

--- a/hooks/market.ts
+++ b/hooks/market.ts
@@ -1,13 +1,13 @@
 import { getServerMarket } from '../service/universalis';
 import { MarketV2 } from '../types/universalis/MarketV2';
-import useSWRImmutable from 'swr/immutable';
+import useSWR from 'swr';
 
 export function useRegionMarket(region: string, itemId: number) {
-  return useSWRImmutable(`$market-${region}-${itemId}`, () => getServerMarket(region, itemId));
+  return useSWR(`$market-${region}-${itemId}`, () => getServerMarket(region, itemId));
 }
 
 export function useDataCenterMarkets(dcNames: string[], itemId: number) {
-  return useSWRImmutable(`$markets-${dcNames.join('-')}-${itemId}`, () =>
+  return useSWR(`$markets-${dcNames.join('-')}-${itemId}`, () =>
     Promise.all(dcNames.map((dcName) => getServerMarket(dcName, itemId))).then(
       (markets) =>
         Object.fromEntries(markets.map((m) => [m.dcName!, m])) as Record<string, MarketV2>
@@ -16,9 +16,9 @@ export function useDataCenterMarkets(dcNames: string[], itemId: number) {
 }
 
 export function useDataCenterMarket(dcName: string, itemId: number) {
-  return useSWRImmutable(`$market-${dcName}-${itemId}`, () => getServerMarket(dcName, itemId));
+  return useSWR(`$market-${dcName}-${itemId}`, () => getServerMarket(dcName, itemId));
 }
 
 export function useWorldMarket(world: string | number, itemId: number) {
-  return useSWRImmutable(`$market-${world}-${itemId}`, () => getServerMarket(world, itemId));
+  return useSWR(`$market-${world}-${itemId}`, () => getServerMarket(world, itemId));
 }

--- a/hooks/market.ts
+++ b/hooks/market.ts
@@ -1,0 +1,24 @@
+import { getServerMarket } from '../service/universalis';
+import { MarketV2 } from '../types/universalis/MarketV2';
+import useSWRImmutable from 'swr/immutable';
+
+export function useRegionMarket(region: string, itemId: number) {
+  return useSWRImmutable(`$market-${region}-${itemId}`, () => getServerMarket(region, itemId));
+}
+
+export function useDataCenterMarkets(dcNames: string[], itemId: number) {
+  return useSWRImmutable(`$markets-${dcNames.join('-')}-${itemId}`, () =>
+    Promise.all(dcNames.map((dcName) => getServerMarket(dcName, itemId))).then(
+      (markets) =>
+        Object.fromEntries(markets.map((m) => [m.dcName!, m])) as Record<string, MarketV2>
+    )
+  );
+}
+
+export function useDataCenterMarket(dcName: string, itemId: number) {
+  return useSWRImmutable(`$market-${dcName}-${itemId}`, () => getServerMarket(dcName, itemId));
+}
+
+export function useWorldMarket(world: string | number, itemId: number) {
+  return useSWRImmutable(`$market-${world}-${itemId}`, () => getServerMarket(world, itemId));
+}

--- a/hooks/useDataCenters.ts
+++ b/hooks/useDataCenters.ts
@@ -1,16 +1,19 @@
 import useSWRImmutable from 'swr/immutable';
 import { getServers } from '../service/servers';
 
-export default function useDataCenters() {
-  return useSWRImmutable('$servers', () =>
-    getServers().then((servers) =>
-      (servers.dcs ?? [])
-        .map((dc) => ({
-          name: dc.name,
-          region: dc.region,
-          worlds: (dc.worlds ?? []).sort((a, b) => a.name.localeCompare(b.name)),
-        }))
-        .sort((a, b) => a.region.localeCompare(b.region))
-    )
+const getSortedServers = () =>
+  getServers().then((servers) =>
+    (servers.dcs ?? [])
+      .map((dc) => ({
+        name: dc.name,
+        region: dc.region,
+        worlds: (dc.worlds ?? []).sort((a, b) => a.name.localeCompare(b.name)),
+      }))
+      .sort((a, b) => a.region.localeCompare(b.region))
+  );
+
+export default function useDataCenters(region?: string) {
+  return useSWRImmutable(`$servers-${region}`, () =>
+    getSortedServers().then((servers) => servers.filter((server) => server.region === region))
   );
 }

--- a/hooks/useDataCenters.ts
+++ b/hooks/useDataCenters.ts
@@ -14,6 +14,8 @@ const getSortedServers = () =>
 
 export default function useDataCenters(region?: string) {
   return useSWRImmutable(`$servers-${region}`, () =>
-    getSortedServers().then((servers) => servers.filter((server) => server.region === region))
+    getSortedServers().then((servers) =>
+      servers.filter((server) => !region || server.region === region)
+    )
   );
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "next-api-decorators": "^2.0.0",
     "next-auth": "^4.18.7",
     "react": "18.2.0",
+    "react-content-loader": "^7.0.0",
     "react-cookie": "^4.1.1",
     "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "18.2.0",
@@ -71,6 +72,6 @@
     "jest-environment-jsdom": "^28.1.2",
     "prettier": "^2.7.1",
     "sass": "^1.52.3",
-    "typescript": "4.7.4"
+    "typescript": "^4.9.0"
   }
 }

--- a/pages/market/[itemId].tsx
+++ b/pages/market/[itemId].tsx
@@ -19,7 +19,7 @@ import MarketItemHeader from '../../components/Market/MarketItemHeader/MarketIte
 import { getItem } from '../../data/game';
 import { Cookies } from 'react-cookie';
 import { World } from '../../types/game/World';
-import { REGIONS, getServers } from '../../service/servers';
+import { REGIONS, Region, Server, getServers } from '../../service/servers';
 import { ParsedUrlQuery } from 'querystring';
 import MarketServerUpdateTimes from '../../components/Market/MarketServerUpdateTimes/MarketServerUpdateTimes';
 import MarketRegion from '../../components/Market/MarketRegion/MarketRegion';
@@ -34,11 +34,6 @@ import { useRegionMarket } from '../../hooks/market';
 import useDataCenters from '../../hooks/useDataCenters';
 
 const isDev = process.env['APP_ENV'] !== 'prod';
-
-type Server =
-  | { type: 'region'; region: string }
-  | { type: 'dc'; dc: DataCenter }
-  | { type: 'world'; world: World };
 
 interface StaticMarketsProps {
   item: Item;
@@ -249,7 +244,7 @@ interface MarketProps {
   lists: UserList[];
   markets: Record<number | string, any>;
   itemId: number;
-  region: string;
+  region: Region;
   homeDc: DataCenter;
   dcs: DataCenter[];
   queryServer: string | null;

--- a/service/servers.ts
+++ b/service/servers.ts
@@ -56,6 +56,10 @@ async function getServersInternal(): Promise<Servers> {
   return cache.servers.value;
 }
 
+export type Region = 'Japan' | 'North-America' | 'Europe' | 'Oceania' | '中国' | '한국';
+
+export const REGIONS = ['Japan', 'North-America', 'Europe', 'Oceania', '中国', '한국'] as const;
+
 export function getServerRegionNameMap(regionStrings: {
   europe: string;
   japan: string;
@@ -64,7 +68,7 @@ export function getServerRegionNameMap(regionStrings: {
   china: string;
   korea: string;
 }) {
-  return new Map<string, string>([
+  return new Map<Region, string>([
     ['Japan', regionStrings.japan],
     ['North-America', regionStrings.america],
     ['Europe', regionStrings.europe],

--- a/service/servers.ts
+++ b/service/servers.ts
@@ -12,6 +12,11 @@ export interface Servers {
   worlds: World[];
 }
 
+export type Server =
+  | { type: 'region'; region: Region }
+  | { type: 'dc'; dc: DataCenter }
+  | { type: 'world'; world: World };
+
 export async function getServers(): Promise<Servers> {
   return retry(getServersInternal, {
     max: 5,

--- a/service/servers.ts
+++ b/service/servers.ts
@@ -37,7 +37,7 @@ async function getServersInternal(): Promise<Servers> {
       .filter((region) => !region.name.includes('Beta'))
       .map((dc) => ({
         name: dc.name,
-        region: dc.region,
+        region: dc.region as Region,
         worlds: dc.worlds.map((worldId) => worlds.find((w) => w.id === worldId)!),
       }));
 

--- a/service/universalis.ts
+++ b/service/universalis.ts
@@ -1,5 +1,11 @@
+import { MarketV2 } from '../types/universalis/MarketV2';
+
 export function getBaseUrl(): string {
   return (
     process.env['API_URL'] || process.env['NEXT_PUBLIC_API_URL'] || 'https://universalis.app/api'
   );
+}
+
+export async function getServerMarket(server: string | number, itemId: number): Promise<MarketV2> {
+  return fetch(`${getBaseUrl()}/v2/${server}/${itemId}`).then((res) => res.json());
 }

--- a/types/game/DataCenter.ts
+++ b/types/game/DataCenter.ts
@@ -1,7 +1,8 @@
+import { Region } from '../../service/servers';
 import { World } from './World';
 
 export interface DataCenter {
   name: string;
-  region: string;
+  region: Region;
   worlds: World[];
 }

--- a/types/universalis/MarketV2.ts
+++ b/types/universalis/MarketV2.ts
@@ -1,0 +1,35 @@
+export interface Listing {
+  lastReviewTime: number;
+  pricePerUnit: number;
+  quantity: number;
+  worldName?: string;
+  worldID?: number;
+  hq: boolean;
+  retainerCity: number;
+  retainerName: string;
+  total: number;
+  tax: number;
+}
+
+export interface Sale {
+  hq: boolean;
+  pricePerUnit: number;
+  quantity: number;
+  timestamp: number;
+  worldName?: string;
+  worldID?: number;
+  buyerName: string;
+  total: number;
+}
+
+export interface MarketV2 {
+  itemID: number;
+  worldID?: number;
+  lastUploadTime: number;
+  listings: Listing[];
+  recentHistory: Sale[];
+  worldName?: string;
+  dcName?: string;
+  regionName?: string;
+  worldUploadTimes?: Record<number, number>;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4816,6 +4816,11 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-content-loader@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/react-content-loader/-/react-content-loader-7.0.0.tgz#785780d10ff40bb5f54ba220ed51e4ad76f13507"
+  integrity sha512-xaBwpO7eiJyEc4ndym+g6wcruV9W2y3DKqbw4U48QFBsv0IeAVZO+aCUb8GptlDLWM8n5zi2HcFSGlj5r+53Tg==
+
 react-cookie@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/react-cookie/-/react-cookie-4.1.1.tgz"
@@ -5550,10 +5555,10 @@ type-fest@^0.21.3:
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
-typescript@4.7.4:
-  version "4.7.4"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+typescript@^4.9.0:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1883,9 +1883,9 @@ can-use-dom@^0.1.0:
   integrity sha512-ceOhN1DL7Y4O6M0j9ICgmTYziV89WMd96SvSl0REd8PMgrY0B/WBOPoed5S1KUmJqXgUXh8gzSe6E3ae27upsQ==
 
 caniuse-lite@^1.0.30001358, caniuse-lite@^1.0.30001400, caniuse-lite@^1.0.30001406:
-  version "1.0.30001512"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001512.tgz"
-  integrity sha512-2S9nK0G/mE+jasCUsMPlARhRCts1ebcp2Ji8Y8PWi4NDE1iRdLCnEPHkEfeBrGC45L4isBx5ur3IQ6yTE2mRZw==
+  version "1.0.30001605"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001605.tgz"
+  integrity sha512-nXwGlFWo34uliI9z3n6Qc0wZaf7zaZWA1CPZ169La5mV3I/gem7bst0vr5XQH5TJXZIMfDeZyOrZnSlVzKxxHQ==
 
 chalk@^2.0.0:
   version "2.4.2"


### PR DESCRIPTION
Adds a server selector for OCE markets on the market item page for non-OCE players. These tabs are not currently expected to preload data like the per-server ones (which scrapers use), so they fetch data on-demand using SWR.

![image](https://github.com/Universalis-FFXIV/mogboard-next/assets/49822414/38e191fe-77f9-47ff-a6c8-f831d3ef696d)
