### PR TITLE
Fix multi-condition search queries and mark next as optional

### DIFF
--- a/service/search.ts
+++ b/service/search.ts
@@ -29,7 +29,7 @@ const BoilmasterItemSearchResult = z.object({
 });
 
 const BoilmasterItemSearchResults = z.object({
-  next: z.string(),
+  next: z.string().optional(),
   results: z.array(
     BoilmasterSheetRow(BoilmasterItemSearchResult).merge(
       z.object({
@@ -139,7 +139,7 @@ export async function searchItemsV2(
   const searchUrl = 'https://beta.xivapi.com/api/1/search';
   const params = new URLSearchParams({
     sheets: 'Item',
-    query: `Name~"${query}" ItemSearchCategory>=1`,
+    query: `+Name~"${query}" +ItemSearchCategory>=1`,
     language: lang,
     limit: '30',
     // LevelItem.todo is a nonexistent field, but using that causes an empty fields


### PR DESCRIPTION
Fix searches that don't match the query at all returning things like crystals etc. This happens because without a MUST operator, when the term query fails, the search results default to satisfying `ItemSearchCategory>=1`, which is all marketable items.