### PR TITLE
Treat words in a search as independent terms

### DIFF
--- a/service/search.ts
+++ b/service/search.ts
@@ -137,9 +137,13 @@ export async function searchItemsV2(
   abort?: AbortController
 ): Promise<ItemSearchResults> {
   const searchUrl = 'https://beta.xivapi.com/api/1/search';
+  const keywords = query
+    .split(' ')
+    .map((term) => `+Name~"${term}"`)
+    .join(' ');
   const params = new URLSearchParams({
     sheets: 'Item',
-    query: `+Name~"${query}" +ItemSearchCategory>=1`,
+    query: `${keywords} +ItemSearchCategory>=1`,
     language: lang,
     limit: '30',
     // LevelItem.todo is a nonexistent field, but using that causes an empty fields


### PR DESCRIPTION
This means that "archeo scouting" will be treated as separate conditions for items containing "archeo" and "scouting", which will then correctly return all Archeo Kingdom scouting equipment.

Previously, the entire search was treated as a single condition, meaning we were searching for items containing the literal "archeo scouting", which would turn up nothing.