### PR TITLE
Derive the %Diff reference price from a less noisy metric

### DIFF
--- a/components/Market/MarketAverages/MarketAverages.tsx
+++ b/components/Market/MarketAverages/MarketAverages.tsx
@@ -37,6 +37,7 @@ export default function MarketAverages({
         </div>
       </div>
       <div>
+        {/* TODO: Why is this useful? Maybe it should just be removed. */}
         <h5>
           <Trans>Avg. Total</Trans>
         </h5>

--- a/components/Market/MarketDataCenter/MarketDataCenter.tsx
+++ b/components/Market/MarketDataCenter/MarketDataCenter.tsx
@@ -12,11 +12,13 @@ import MarketHistoryGraph from '../MarketHistoryGraph/MarketHistoryGraph';
 import MarketStackSizeHistogram from '../MarketStackSizeHistogram/MarketStackSizeHistogram';
 import { useDataCenterMarket } from '../../../hooks/market';
 import MarketWorld from '../MarketWorld/MarketWorld';
+import { MarketV2 } from '../../../types/universalis/MarketV2';
+import { calculateReferencePrice, Quality } from '../utils';
 
 interface MarketDataCenterProps {
   item: Item;
   dc: DataCenter;
-  market: any;
+  market: MarketV2;
   lang: Language;
   open: boolean;
 }
@@ -26,55 +28,50 @@ function entriesToShow(entries: {}[]) {
 }
 
 export default function MarketDataCenter({ item, dc, market, lang, open }: MarketDataCenterProps) {
-  const hqListings = market.listings?.filter((listing: any) => listing.hq) ?? [];
-  const nqListings = market.listings?.filter((listing: any) => !listing.hq) ?? [];
-  const hqSales = market.recentHistory?.filter((sale: any) => sale.hq) ?? [];
-  const nqSales = market.recentHistory?.filter((sale: any) => !sale.hq) ?? [];
+  const hqListings = market.listings?.filter((listing) => listing.hq) ?? [];
+  const nqListings = market.listings?.filter((listing) => !listing.hq) ?? [];
+  const hqSales = market.recentHistory?.filter((sale) => sale.hq) ?? [];
+  const nqSales = market.recentHistory?.filter((sale) => !sale.hq) ?? [];
 
   const hqListingsAveragePpu =
     Math.ceil(
-      hqListings
-        .map((listing: any) => listing.pricePerUnit)
-        .reduce((agg: any, next: any) => agg + next, 0) / hqListings.length
+      hqListings.map((listing) => listing.pricePerUnit).reduce((agg, next) => agg + next, 0) /
+        hqListings.length
     ) || 0;
   const nqListingsAveragePpu =
     Math.ceil(
-      nqListings
-        .map((listing: any) => listing.pricePerUnit)
-        .reduce((agg: any, next: any) => agg + next, 0) / nqListings.length
+      nqListings.map((listing) => listing.pricePerUnit).reduce((agg, next) => agg + next, 0) /
+        nqListings.length
     ) || 0;
   const hqListingsAverageTotal =
     Math.ceil(
-      hqListings
-        .map((listing: any) => listing.total)
-        .reduce((agg: any, next: any) => agg + next, 0) / hqListings.length
+      hqListings.map((listing) => listing.total).reduce((agg, next) => agg + next, 0) /
+        hqListings.length
     ) || 0;
   const nqListingsAverageTotal =
     Math.ceil(
-      nqListings
-        .map((listing: any) => listing.total)
-        .reduce((agg: any, next: any) => agg + next, 0) / nqListings.length
+      nqListings.map((listing) => listing.total).reduce((agg, next) => agg + next, 0) /
+        nqListings.length
     ) || 0;
   const hqSalesAveragePpu =
     Math.ceil(
-      hqSales.map((sale: any) => sale.pricePerUnit).reduce((agg: any, next: any) => agg + next, 0) /
-        hqSales.length
+      hqSales.map((sale) => sale.pricePerUnit).reduce((agg, next) => agg + next, 0) / hqSales.length
     ) || 0;
   const nqSalesAveragePpu =
     Math.ceil(
-      nqSales.map((sale: any) => sale.pricePerUnit).reduce((agg: any, next: any) => agg + next, 0) /
-        nqSales.length
+      nqSales.map((sale) => sale.pricePerUnit).reduce((agg, next) => agg + next, 0) / nqSales.length
     ) || 0;
   const hqSalesAverageTotal =
     Math.ceil(
-      hqSales.map((sale: any) => sale.total).reduce((agg: any, next: any) => agg + next, 0) /
-        hqSales.length
+      hqSales.map((sale) => sale.total).reduce((agg, next) => agg + next, 0) / hqSales.length
     ) || 0;
   const nqSalesAverageTotal =
     Math.ceil(
-      nqSales.map((sale: any) => sale.total).reduce((agg: any, next: any) => agg + next, 0) /
-        nqSales.length
+      nqSales.map((sale) => sale.total).reduce((agg, next) => agg + next, 0) / nqSales.length
     ) || 0;
+
+  const nqReferencePrice = calculateReferencePrice(market, Quality.NormalQuality);
+  const hqReferencePrice = calculateReferencePrice(market, Quality.HighQuality);
 
   return (
     <>
@@ -94,8 +91,8 @@ export default function MarketDataCenter({ item, dc, market, lang, open }: Marke
               </h6>
               <ListingsTable
                 listings={hqListings}
-                averageHq={hqListingsAveragePpu}
-                averageNq={nqListingsAveragePpu}
+                averageHq={hqReferencePrice}
+                averageNq={nqReferencePrice}
                 crossWorld={true}
                 includeDiff={true}
                 lang={lang}
@@ -108,8 +105,8 @@ export default function MarketDataCenter({ item, dc, market, lang, open }: Marke
           <h6>{sprintf(t`%s Prices`, 'NQ')}</h6>
           <ListingsTable
             listings={nqListings}
-            averageHq={hqListingsAveragePpu}
-            averageNq={nqListingsAveragePpu}
+            averageHq={hqReferencePrice}
+            averageNq={nqReferencePrice}
             crossWorld={true}
             includeDiff={true}
             lang={lang}
@@ -126,8 +123,8 @@ export default function MarketDataCenter({ item, dc, market, lang, open }: Marke
               </h6>
               <SalesTable
                 sales={hqSales}
-                averageHq={hqSalesAveragePpu}
-                averageNq={nqSalesAveragePpu}
+                averageHq={hqReferencePrice}
+                averageNq={nqReferencePrice}
                 crossWorld={true}
                 includeDiff={true}
                 start={0}
@@ -139,8 +136,8 @@ export default function MarketDataCenter({ item, dc, market, lang, open }: Marke
           <h6>{sprintf(t`%s Purchase History`, 'NQ')}</h6>
           <SalesTable
             sales={nqSales}
-            averageHq={hqSalesAveragePpu}
-            averageNq={nqSalesAveragePpu}
+            averageHq={hqReferencePrice}
+            averageNq={nqReferencePrice}
             crossWorld={true}
             includeDiff={true}
             start={0}

--- a/components/Market/MarketRegion/MarketRegion.tsx
+++ b/components/Market/MarketRegion/MarketRegion.tsx
@@ -11,15 +11,15 @@ import MarketCheapest from '../MarketCheapest/MarketCheapest';
 import MarketHistoryGraph from '../MarketHistoryGraph/MarketHistoryGraph';
 import MarketStackSizeHistogram from '../MarketStackSizeHistogram/MarketStackSizeHistogram';
 import { useDataCenterMarkets } from '../../../hooks/market';
-import ErrorBoundary from '../../ErrorBoundary/ErrorBoundary';
-import { Suspense } from 'react';
 import MarketWorld from '../MarketWorld/MarketWorld';
+import { MarketV2 } from '../../../types/universalis/MarketV2';
+import { calculateReferencePrice, Quality } from '../utils';
 
 interface MarketRegionProps {
   item: Item;
   region: string;
   dcs: DataCenter[];
-  dcMarkets: Record<string, any>;
+  dcMarkets: Record<string, MarketV2>;
   lang: Language;
   open: boolean;
 }
@@ -47,55 +47,50 @@ export default function MarketRegion({
     .flat()
     .sort((a, b) => b.timestamp - a.timestamp);
 
-  const hqListings = allListings?.filter((listing: any) => listing.hq) ?? [];
-  const nqListings = allListings?.filter((listing: any) => !listing.hq) ?? [];
-  const hqSales = allSales?.filter((sale: any) => sale.hq) ?? [];
-  const nqSales = allSales?.filter((sale: any) => !sale.hq) ?? [];
+  const hqListings = allListings?.filter((listing) => listing.hq) ?? [];
+  const nqListings = allListings?.filter((listing) => !listing.hq) ?? [];
+  const hqSales = allSales?.filter((sale) => sale.hq) ?? [];
+  const nqSales = allSales?.filter((sale) => !sale.hq) ?? [];
 
   const hqListingsAveragePpu =
     Math.ceil(
-      hqListings
-        .map((listing: any) => listing.pricePerUnit)
-        .reduce((agg: any, next: any) => agg + next, 0) / hqListings.length
+      hqListings.map((listing) => listing.pricePerUnit).reduce((agg, next) => agg + next, 0) /
+        hqListings.length
     ) || 0;
   const nqListingsAveragePpu =
     Math.ceil(
-      nqListings
-        .map((listing: any) => listing.pricePerUnit)
-        .reduce((agg: any, next: any) => agg + next, 0) / nqListings.length
+      nqListings.map((listing) => listing.pricePerUnit).reduce((agg, next) => agg + next, 0) /
+        nqListings.length
     ) || 0;
   const hqListingsAverageTotal =
     Math.ceil(
-      hqListings
-        .map((listing: any) => listing.total)
-        .reduce((agg: any, next: any) => agg + next, 0) / hqListings.length
+      hqListings.map((listing) => listing.total).reduce((agg, next) => agg + next, 0) /
+        hqListings.length
     ) || 0;
   const nqListingsAverageTotal =
     Math.ceil(
-      nqListings
-        .map((listing: any) => listing.total)
-        .reduce((agg: any, next: any) => agg + next, 0) / nqListings.length
+      nqListings.map((listing) => listing.total).reduce((agg, next) => agg + next, 0) /
+        nqListings.length
     ) || 0;
   const hqSalesAveragePpu =
     Math.ceil(
-      hqSales.map((sale: any) => sale.pricePerUnit).reduce((agg: any, next: any) => agg + next, 0) /
-        hqSales.length
+      hqSales.map((sale) => sale.pricePerUnit).reduce((agg, next) => agg + next, 0) / hqSales.length
     ) || 0;
   const nqSalesAveragePpu =
     Math.ceil(
-      nqSales.map((sale: any) => sale.pricePerUnit).reduce((agg: any, next: any) => agg + next, 0) /
-        nqSales.length
+      nqSales.map((sale) => sale.pricePerUnit).reduce((agg, next) => agg + next, 0) / nqSales.length
     ) || 0;
   const hqSalesAverageTotal =
     Math.ceil(
-      hqSales.map((sale: any) => sale.total).reduce((agg: any, next: any) => agg + next, 0) /
-        hqSales.length
+      hqSales.map((sale) => sale.total).reduce((agg, next) => agg + next, 0) / hqSales.length
     ) || 0;
   const nqSalesAverageTotal =
     Math.ceil(
-      nqSales.map((sale: any) => sale.total).reduce((agg: any, next: any) => agg + next, 0) /
-        nqSales.length
+      nqSales.map((sale) => sale.total).reduce((agg, next) => agg + next, 0) / nqSales.length
     ) || 0;
+
+  const nqReferencePrice = calculateReferencePrice(dcMarkets, Quality.NormalQuality);
+  const hqReferencePrice = calculateReferencePrice(dcMarkets, Quality.HighQuality);
 
   return (
     <>
@@ -115,8 +110,8 @@ export default function MarketRegion({
               </h6>
               <ListingsTable
                 listings={hqListings}
-                averageHq={hqListingsAveragePpu}
-                averageNq={nqListingsAveragePpu}
+                averageHq={hqReferencePrice}
+                averageNq={nqReferencePrice}
                 crossWorld={true}
                 crossDc={true}
                 dcs={dcs}
@@ -131,8 +126,8 @@ export default function MarketRegion({
           <h6>{sprintf(t`%s Prices`, 'NQ')}</h6>
           <ListingsTable
             listings={nqListings}
-            averageHq={hqListingsAveragePpu}
-            averageNq={nqListingsAveragePpu}
+            averageHq={hqReferencePrice}
+            averageNq={nqReferencePrice}
             crossWorld={true}
             crossDc={true}
             dcs={dcs}
@@ -151,8 +146,8 @@ export default function MarketRegion({
               </h6>
               <SalesTable
                 sales={hqSales}
-                averageHq={hqSalesAveragePpu}
-                averageNq={nqSalesAveragePpu}
+                averageHq={hqReferencePrice}
+                averageNq={nqReferencePrice}
                 crossWorld={true}
                 crossDc={true}
                 dcs={dcs}
@@ -166,8 +161,8 @@ export default function MarketRegion({
           <h6>{sprintf(t`%s Purchase History`, 'NQ')}</h6>
           <SalesTable
             sales={nqSales}
-            averageHq={hqSalesAveragePpu}
-            averageNq={nqSalesAveragePpu}
+            averageHq={hqReferencePrice}
+            averageNq={nqReferencePrice}
             crossWorld={true}
             crossDc={true}
             dcs={dcs}

--- a/components/Market/MarketWorld/MarketWorld.tsx
+++ b/components/Market/MarketWorld/MarketWorld.tsx
@@ -11,11 +11,13 @@ import MarketStackSizeHistogram from '../MarketStackSizeHistogram/MarketStackSiz
 import NoMarketData from '../NoMarketData/NoMarketData';
 import { useWorldMarket } from '../../../hooks/market';
 import ContentLoader from 'react-content-loader';
+import { MarketV2 } from '../../../types/universalis/MarketV2';
+import { calculateReferencePrice, Quality } from '../utils';
 
 interface MarketWorldProps {
   item: Item;
   world: World;
-  market: any;
+  market: MarketV2;
   lang: Language;
   open: boolean;
 }
@@ -33,6 +35,9 @@ export default function MarketWorld({ item, world, market, lang, open }: MarketW
     return <NoMarketData worldName={world.name} />;
   }
 
+  const nqReferencePrice = calculateReferencePrice(market, Quality.NormalQuality);
+  const hqReferencePrice = calculateReferencePrice(market, Quality.HighQuality);
+
   return (
     <>
       <div className="tab-market-tables">
@@ -47,8 +52,8 @@ export default function MarketWorld({ item, world, market, lang, open }: MarketW
           </h4>
           <ListingsTable
             listings={market.listings}
-            averageHq={market.currentAveragePriceHQ}
-            averageNq={market.currentAveragePriceNQ}
+            averageHq={hqReferencePrice}
+            averageNq={nqReferencePrice}
             crossWorld={false}
             includeDiff={true}
             lang={lang}
@@ -62,8 +67,8 @@ export default function MarketWorld({ item, world, market, lang, open }: MarketW
           </h4>
           <SalesTable
             sales={market.recentHistory}
-            averageHq={market.averagePriceHQ}
-            averageNq={market.averagePriceNQ}
+            averageHq={hqReferencePrice}
+            averageNq={nqReferencePrice}
             crossWorld={false}
             includeDiff={true}
             start={0}

--- a/components/Market/utils.ts
+++ b/components/Market/utils.ts
@@ -1,0 +1,83 @@
+import { MarketV2, Sale } from '../../types/universalis/MarketV2';
+
+export const enum Quality {
+  NormalQuality,
+  HighQuality,
+}
+
+/**
+ * Calculates the reference price used for %Diff calculations.
+ *
+ * @param market The API response to use for the calculation.
+ * @param quality The quality to limit the calculation to.
+ */
+export function calculateReferencePrice(market: MarketV2, quality: Quality): number;
+export function calculateReferencePrice(market: Record<string, MarketV2>, quality: Quality): number;
+export function calculateReferencePrice(
+  market: MarketV2 | Record<string, MarketV2>,
+  quality: Quality
+): number {
+  // The reference price is the median of the last 7 days of sales
+  const sales = concatSales(market).filter(isQuality(quality)).filter(withinDays(7));
+  if (sales.length === 0) {
+    return 0;
+  }
+
+  const averageUnitPrice = median(sales.map((sale) => sale.pricePerUnit));
+  return averageUnitPrice;
+}
+
+/**
+ * Returns all sales from the provided API responses.
+ *
+ * @param marketOrMarkets The input market data.
+ * @returns The concatenated sales.
+ */
+function concatSales(marketOrMarkets: MarketV2 | Record<string, MarketV2>): Sale[] {
+  if ('recentHistory' in marketOrMarkets) {
+    const market = marketOrMarkets as MarketV2;
+    return market.recentHistory ?? [];
+  } else {
+    const markets = marketOrMarkets as Record<string, MarketV2>;
+    const sales = Object.values(markets)
+      .map((market) => market.recentHistory ?? [])
+      .flat();
+    return sales;
+  }
+}
+
+function median(values: number[]): number {
+  const sortedValues = values.slice().sort((a, b) => a - b);
+
+  const length = sortedValues.length;
+  const medianIndex = Math.floor(length / 2);
+  if (length % 2 !== 0) {
+    return sortedValues[medianIndex];
+  } else {
+    return (sortedValues[medianIndex - 1] + sortedValues[medianIndex]) / 2;
+  }
+}
+
+function isDistinctMedianIndex(idx: number): boolean {
+  return Math.trunc(idx) === idx;
+}
+
+const SECONDS_PER_DAY = 86400;
+
+function withinDays(days: number) {
+  const maxTimeDiff = days * SECONDS_PER_DAY;
+  const now = Date.now() / 1000;
+  return function (sale: Sale): boolean {
+    return now - sale.timestamp <= maxTimeDiff;
+  };
+}
+
+function isQuality(quality: Quality) {
+  return function (sale: Sale): boolean {
+    if (quality === Quality.HighQuality) {
+      return sale.hq;
+    } else {
+      return !sale.hq;
+    }
+  };
+}

--- a/types/universalis/MarketV2.ts
+++ b/types/universalis/MarketV2.ts
@@ -32,4 +32,11 @@ export interface MarketV2 {
   dcName?: string;
   regionName?: string;
   worldUploadTimes?: Record<number, number>;
+  currentAveragePriceNQ: number;
+  currentAveragePriceHQ: number;
+  averagePriceNQ: number;
+  averagePriceHQ: number;
+  stackSizeHistogram: Record<`${number}`, number>;
+  stackSizeHistogramNQ: Record<`${number}`, number>;
+  stackSizeHistogramHQ: Record<`${number}`, number>;
 }


### PR DESCRIPTION
Changes the %Diff reference price to use the median unit price of the last 7 days of sales. This will make it based on the actual selling price and less vulnerable to high-priced listings shifting the value to an unrealistic amount.

This aims to make the %Diff more useful for sellers and purchasers by communicating something about what the useful selling prices are, rather than whatever the current arbitrary listing prices are.

Fixes https://github.com/Universalis-FFXIV/Universalis/issues/1394.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced average price calculations using a new utility function for improved pricing accuracy.
	- Introduced a `Quality` enum for better categorization of market data.
	- Added new properties to the market data structure for detailed pricing and histogram information.

- **Bug Fixes**
	- Streamlined code in various components for better performance and maintainability.

- **Documentation**
	- Added comments to clarify the purpose of average total values in the `MarketAverages` component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->