### PR TITLE
Add automatic filtering of obsolete crafting materials

### DIFF
--- a/components/Home/HomeLeastRecentlyUpdated/HomeLeastRecentlyUpdated.tsx
+++ b/components/Home/HomeLeastRecentlyUpdated/HomeLeastRecentlyUpdated.tsx
@@ -8,6 +8,36 @@ import styles from './HomeLeastRecentlyUpdated.module.scss';
 import ago from 's-ago';
 import SimpleBar from 'simplebar-react';
 
+// Item search categories for crafting materials where we filter out items not used in recipes
+const CRAFTING_MATERIAL_CATEGORIES = new Set([
+  44, // Ingredients
+  46, // Seafood
+  47, // Stone
+  48, // Metal
+  49, // Lumber
+  50, // Cloth
+  51, // Leather
+  52, // Bone
+  53, // Reagents
+  55, // Weapon Parts
+  58, // Crystals
+  59, // Catalysts
+]);
+
+/**
+ * Determines if an item should be shown in the least recently updated list.
+ * Filters out obsolete crafting materials that are no longer used in any recipes.
+ */
+function shouldShowItem(item: Item): boolean {
+  // Only filter items in crafting material categories
+  if (!CRAFTING_MATERIAL_CATEGORIES.has(item.itemSearchCategory)) {
+    return true;
+  }
+
+  // For crafting materials, only show if they're used in at least one recipe
+  return item.isUsedInRecipe;
+}
+
 function ItemEntryCrossWorld({
   item,
   date,
@@ -117,7 +147,7 @@ export default function HomeLeastRecentlyUpdated({
           <SimpleBar style={{ height: '40vh' }}>
             {leastRecents
               .map((lr) => ({ item: getItem(lr.id, lang), date: lr.date, world: lr.world }))
-              .filter((entry) => entry.item != null)
+              .filter((entry) => entry.item != null && shouldShowItem(entry.item))
               .map((entry, i) => (
                 <ItemEntryCrossWorld
                   key={i}
@@ -143,7 +173,7 @@ export default function HomeLeastRecentlyUpdated({
           <SimpleBar style={{ height: '40vh' }}>
             {leastRecents
               .map((lr) => ({ item: getItem(lr.id, lang), date: lr.date, world: lr.world }))
-              .filter((entry) => entry.item != null)
+              .filter((entry) => entry.item != null && shouldShowItem(entry.item))
               .map((entry, i) => (
                 <ItemEntryWorld key={i} item={entry.item!} date={entry.date} lang={lang} />
               ))}

--- a/tools/MogboardExporter/MogboardExporter.Data/Dumps.cs
+++ b/tools/MogboardExporter/MogboardExporter.Data/Dumps.cs
@@ -50,7 +50,7 @@ public class ItemDump
     [JsonPropertyName("name")] public string? Name { get; init; }
 
     [JsonPropertyName("description")] public string? Description { get; init; }
-    
+
     [JsonPropertyName("iconId")] public uint IconId { get; init; }
 
     [JsonPropertyName("levelItem")] public uint LevelItem { get; init; }
@@ -71,4 +71,6 @@ public class ItemDump
     [JsonPropertyName("itemUiCategory")] public uint ItemUICategory { get; init; }
 
     [JsonPropertyName("classJobCategory")] public uint ClassJobCategory { get; init; }
+
+    [JsonPropertyName("isUsedInRecipe")] public bool IsUsedInRecipe { get; init; }
 }

--- a/types/game/Item.ts
+++ b/types/game/Item.ts
@@ -12,4 +12,5 @@ export interface Item {
   itemSearchCategory: number;
   itemUiCategory: number;
   classJobCategory: number;
+  isUsedInRecipe: boolean;
 }


### PR DESCRIPTION
This change programmatically filters out crafting materials that are no longer used in any recipes from the "Least Recently Updated Items" list.

Changes:
- Add isUsedInRecipe field to Item interface and ItemDump class
- Update game data exporter to build recipe usage index from Recipe sheet
- Filter items in material categories (Lumber, Leather, Metal, etc.) that aren't used in any current recipes
- Conservative approach: only filters specific crafting material categories, preserving all equipment, consumables, and other item types

This resolves issues with obsolete items like:
- Lindwurm Skin, Nakki Skin (removed leather materials)
- Ebony Branch, Lauan Plank (removed lumber materials)
- ARR beast tribe slag items
- Other deprecated crafting materials

Note: Requires re-running the MogboardExporter to regenerate items.json with the new isUsedInRecipe field populated from game data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smarter item filtering: crafting materials are now hidden unless they’re used in recipes, reducing clutter in lists and views.
  * Enhanced item tracking: items carry recipe-usage information so the UI can selectively surface items based on whether they appear in recipes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->