### PR TITLE
Add hide price cents setting

### DIFF
--- a/components/Market/ListingsTable/ListingsTable.tsx
+++ b/components/Market/ListingsTable/ListingsTable.tsx
@@ -67,9 +67,10 @@ function ListingsTableHeader({
 interface ListingsTableRowProps {
   listing: ListingRow;
   includeGst: boolean;
+  hidePriceCents: boolean;
 }
 
-function ListingsTableRow({ listing, includeGst }: ListingsTableRowProps) {
+function ListingsTableRow({ listing, includeGst, hidePriceCents }: ListingsTableRowProps) {
   return (
     <tr>
       <td className="price-num tac">{listing.n}</td>
@@ -98,7 +99,7 @@ function ListingsTableRow({ listing, includeGst }: ListingsTableRowProps) {
       <td className="price-current">
         {listing.pricePerUnit.toLocaleString(
           undefined,
-          includeGst
+          includeGst && !hidePriceCents
             ? {
                 minimumFractionDigits: 2,
                 maximumFractionDigits: 2,
@@ -155,6 +156,7 @@ export default function ListingsTable({
 }: ListingsTableProps) {
   const [settings] = useSettings();
   const includeGst = settings.includeGst === 'yes';
+  const hidePriceCents = settings.hidePriceCents === 'yes';
 
   const listingRows: ListingRow[] = listings
     .sort((a, b) => a.pricePerUnit - b.pricePerUnit)
@@ -253,7 +255,7 @@ export default function ListingsTable({
           </tr>
         }
       >
-        {(listing) => <ListingsTableRow listing={listing} includeGst={includeGst} />}
+        {(listing) => <ListingsTableRow listing={listing} includeGst={includeGst} hidePriceCents={hidePriceCents} />}
       </SortTable>
     </div>
   );

--- a/components/UniversalisLayout/components/SettingsModal/SettingsModal.tsx
+++ b/components/UniversalisLayout/components/SettingsModal/SettingsModal.tsx
@@ -25,6 +25,7 @@ export default function SettingsModal({ isOpen, closeModal, onSave }: SettingsMo
     settings['mogboard_homeworld'] ?? 'no'
   );
   const [includeGst, setIncludeGst] = useState(settings.includeGst ?? 'no');
+  const [hidePriceCents, setHidePriceCents] = useState(settings.hidePriceCents ?? 'no');
 
   const [settingsData, setSettingsData] = useState<{ timezones: TimeZone[] }>({
     timezones: [],
@@ -215,6 +216,36 @@ export default function SettingsModal({ isOpen, closeModal, onSave }: SettingsMo
                 </select>
               </div>
             </div>
+            <div className="flex_50">
+              <label htmlFor="hidepricecents">
+                <Trans>Hide Price Cents</Trans>
+              </label>
+              <div style={{ paddingBottom: 10 }}>
+                <small>
+                  <Trans>This will hide the decimal point and cents values in price displays.</Trans>
+                </small>
+              </div>
+              <div className="form">
+                <select
+                  value={hidePriceCents}
+                  id="hidepricecents"
+                  className="hidepricecents"
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    if (hidePriceCents !== val && (val === 'yes' || val === 'no')) {
+                      setHidePriceCents(val);
+                    }
+                  }}
+                >
+                  <option value="no">
+                    <Trans>No</Trans>
+                  </option>
+                  <option value="yes">
+                    <Trans>Yes</Trans>
+                  </option>
+                </select>
+              </div>
+            </div>
           </div>
         </div>
 
@@ -229,6 +260,7 @@ export default function SettingsModal({ isOpen, closeModal, onSave }: SettingsMo
               setSetting('mogboard_leftnav', showLeftNav);
               setSetting('mogboard_homeworld', showDefaultHomeWorld);
               setSetting('includeGst', includeGst);
+              setSetting('hidePriceCents', hidePriceCents);
               onSave();
             }}
           >

--- a/hooks/useSettings.ts
+++ b/hooks/useSettings.ts
@@ -15,6 +15,7 @@ interface Settings extends LegacySettings {
   listCrossDc: 'yes' | 'no';
   listHqOnly: 'yes' | 'no';
   includeGst: 'yes' | 'no';
+  hidePriceCents: 'yes' | 'no';
 }
 
 function validateLanguage(
@@ -45,6 +46,7 @@ export default function useSettings(): [
     'listHqOnly',
     'listCrossDc',
     'includeGst',
+    'hidePriceCents',
   ];
 
   const [cookies, setCookie] = useCookies<keyof Settings, Partial<Settings>>(keys);


### PR DESCRIPTION
Add a new user setting to hide decimal places in price displays. This setting:
- Defaults to showing decimals (no = show decimals)
- Works in conjunction with the "Include Tax" setting
- When enabled (yes), hides the .00 cents from prices
- UI toggle added to Settings modal next to "Include Tax" option

This addresses user request to view tax-included prices without the decimal values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Hide Price Cents" setting to the Settings modal, allowing users to customize price display format.
  * Users can now toggle the display of fractional cents in market listing prices.
  * When enabled, prices display as whole numbers without cents.
  * The preference is automatically saved and persists across all sessions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->