### PR TITLE
Fix weird decimals when hidePriceCents is true sometimes

### DIFF
--- a/components/Market/ListingsTable/ListingsTable.tsx
+++ b/components/Market/ListingsTable/ListingsTable.tsx
@@ -99,10 +99,10 @@ function ListingsTableRow({ listing, includeGst, hidePriceCents }: ListingsTable
       <td className="price-current">
         {listing.pricePerUnit.toLocaleString(
           undefined,
-          includeGst && !hidePriceCents
+          includeGst
             ? {
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2,
+                minimumFractionDigits: !hidePriceCents ? 2 : 0,
+                maximumFractionDigits: !hidePriceCents ? 2 : 0,
               }
             : undefined
         )}
@@ -255,7 +255,13 @@ export default function ListingsTable({
           </tr>
         }
       >
-        {(listing) => <ListingsTableRow listing={listing} includeGst={includeGst} hidePriceCents={hidePriceCents} />}
+        {(listing) => (
+          <ListingsTableRow
+            listing={listing}
+            includeGst={includeGst}
+            hidePriceCents={hidePriceCents}
+          />
+        )}
       </SortTable>
     </div>
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved price display formatting in the listings table. Prices now consistently apply formatting when GST is included, with decimal place precision correctly adjusting based on your hide cents preference (2 decimals when shown, 0 when hidden).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->