### PR TITLE
Adds support for Traditional Chinese region

### DIFF
--- a/components/Market/MarketServerSelector/MarketServerSelector.tsx
+++ b/components/Market/MarketServerSelector/MarketServerSelector.tsx
@@ -21,6 +21,7 @@ const regionNameMapping = getServerRegionNameMap({
   oceania: t`Oceania`,
   china: t`中国`,
   korea: t`한국`,
+  traditionalChinese: t`繁中服`,
 });
 
 export default function MarketServerSelector({

--- a/components/WorldOption/WorldOption.tsx
+++ b/components/WorldOption/WorldOption.tsx
@@ -17,6 +17,7 @@ export default function WorldOption({ value, setValue }: WorldOptionProps) {
     oceania: t`Oceania`,
     china: t`中国`,
     korea: t`한국`,
+    traditionalChinese: t`繁中服`,
   });
 
   return (

--- a/service/servers.ts
+++ b/service/servers.ts
@@ -61,9 +61,9 @@ async function getServersInternal(): Promise<Servers> {
   return cache.servers.value;
 }
 
-export type Region = 'Japan' | 'North-America' | 'Europe' | 'Oceania' | '中国' | '한국';
+export type Region = 'Japan' | 'North-America' | 'Europe' | 'Oceania' | '中国' | '한국' | '繁中服';
 
-export const REGIONS = ['Japan', 'North-America', 'Europe', 'Oceania', '中国', '한국'] as const;
+export const REGIONS = ['Japan', 'North-America', 'Europe', 'Oceania', '中国', '한국', '繁中服'] as const;
 
 export function getServerRegionNameMap(regionStrings: {
   europe: string;
@@ -72,6 +72,7 @@ export function getServerRegionNameMap(regionStrings: {
   oceania: string;
   china: string;
   korea: string;
+  traditionalChinese: string;
 }) {
   return new Map<Region, string>([
     ['Japan', regionStrings.japan],
@@ -80,5 +81,6 @@ export function getServerRegionNameMap(regionStrings: {
     ['Oceania', regionStrings.oceania],
     ['中国', regionStrings.china],
     ['한국', regionStrings.korea],
+    ['繁中服', regionStrings.traditionalChinese],
   ]);
 }


### PR DESCRIPTION
Adds the "繁中服" (Traditional Chinese) region as a selectable option in the market server and world selection components.

This enhancement broadens the region selection to include Traditional Chinese servers, improving the user experience for players in that region.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Traditional Chinese server region, enabling users to select this region when configuring their server preferences.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->