### PR TITLE
chore: add debug logging for alerts endpoint

### DIFF
--- a/pages/api/web/alerts/index.ts
+++ b/pages/api/web/alerts/index.ts
@@ -27,7 +27,8 @@ class AlertsHandler {
         return res.status(400).json({ message: 'Maximum number of alerts has been created.' });
       }
     } catch (err) {
-      console.error(err);
+      console.log('ALERT_CREATE_VALIDATE_ERROR: ' + String(err));
+      console.log('ALERT_CREATE_VALIDATE_STACK: ' + (err instanceof Error ? err.stack : 'no stack'));
       return res.status(500).json({ message: 'An error occurred.' });
     }
 
@@ -46,7 +47,8 @@ class AlertsHandler {
     try {
       await Database.createUserAlert(alert);
     } catch (err) {
-      console.error(err);
+      console.log('ALERT_CREATE_INSERT_ERROR: ' + String(err));
+      console.log('ALERT_CREATE_INSERT_STACK: ' + (err instanceof Error ? err.stack : 'no stack'));
       return res.status(500).json({ message: 'An error occurred.' });
     }
 
@@ -66,7 +68,8 @@ class AlertsHandler {
       const userAlerts = await Database.getUserAlerts(session.user.id);
       alerts.push(...userAlerts);
     } catch (err) {
-      console.error(err);
+      console.log('ALERT_FETCH_ERROR: ' + String(err));
+      console.log('ALERT_FETCH_STACK: ' + (err instanceof Error ? err.stack : 'no stack'));
       return res.status(500).json({ message: 'An error occurred.' });
     }
 


### PR DESCRIPTION
Add debug logging to the alerts endpoint to debug "An error occurred." and a 500 on the alerts page. These errors do not appear to be logged right now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error logging for alert operations with structured error messages and stack traces for better debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->