### PR TITLE
Support navigating to a world's listings via the update time

### DIFF
--- a/components/LinkButton/LinkButton.module.scss
+++ b/components/LinkButton/LinkButton.module.scss
@@ -1,0 +1,9 @@
+.linkButton {
+  all: unset;
+  cursor: pointer;
+}
+
+.linkButton:focus {
+  all: unset;
+  outline: revert;
+}

--- a/components/LinkButton/LinkButton.tsx
+++ b/components/LinkButton/LinkButton.tsx
@@ -1,0 +1,15 @@
+import { ReactElement } from 'react';
+import styles from './LinkButton.module.scss';
+
+export interface LinkButtonProps {
+  onClick: () => void;
+  children: string | ReactElement | ReactElement[];
+}
+
+export default function LinkButton({ onClick, children }: LinkButtonProps) {
+  return (
+    <button type="button" className={styles.linkButton} onClick={onClick}>
+      {children}
+    </button>
+  );
+}

--- a/components/Market/MarketRegionUpdateTimes/MarketRegionUpdateTimes.tsx
+++ b/components/Market/MarketRegionUpdateTimes/MarketRegionUpdateTimes.tsx
@@ -2,16 +2,20 @@ import { t } from '@lingui/macro';
 import { Suspense } from 'react';
 import ago from 's-ago';
 import SimpleBar from 'simplebar-react';
+import { Server } from '../../../service/servers';
 import { DataCenter } from '../../../types/game/DataCenter';
+import LinkButton from '../../LinkButton/LinkButton';
 
 interface MarketRegionUpdateTimesProps {
   dcs: DataCenter[];
   worldUploadTimes: Record<number, number>;
+  setSelectedServer: (server: Server) => void;
 }
 
 export default function MarketRegionUpdateTimes({
   dcs,
   worldUploadTimes,
+  setSelectedServer,
 }: MarketRegionUpdateTimesProps) {
   return (
     <SimpleBar style={{ width: '100%' }}>
@@ -20,7 +24,11 @@ export default function MarketRegionUpdateTimes({
           <div key={dc.name}>
             {dc.worlds.map((world) => (
               <div key={world.id}>
-                <h4>{world.name}</h4>
+                <h4>
+                  <LinkButton onClick={() => setSelectedServer({ type: 'world', world })}>
+                    {world.name}
+                  </LinkButton>
+                </h4>
                 <div>
                   <Suspense>
                     {worldUploadTimes[world.id]

--- a/components/Market/MarketServerSelector/MarketServerSelector.tsx
+++ b/components/Market/MarketServerSelector/MarketServerSelector.tsx
@@ -24,6 +24,53 @@ const regionNameMapping = getServerRegionNameMap({
   traditionalChinese: t`繁中服`,
 });
 
+const getShownWorlds = (
+  selectedServer: Server,
+  regions: readonly Region[],
+  dcs: readonly DataCenter[],
+  homeDc: DataCenter | undefined
+) => {
+  // Filter worlds to only show those from the currently-selected data center, prioritizing the user's home server if provided.
+  // For regions in all other cases, show all worlds within the region. This is really scuffed but it shows the correct worlds
+  // in each server selector in all the scenarios I tested. We should maybe save if we got to a selected world from a selected
+  // DC or region so we can persist that scope when selecting a world after that?
+  const selectedRegionRollup =
+    selectedServer.type === 'region'
+      ? selectedServer.region
+      : selectedServer.type === 'dc'
+      ? selectedServer.dc.region
+      : dcs.find((dc) => dc.worlds.some((w) => w.id === selectedServer.world.id))?.region;
+  if (!homeDc && (!selectedRegionRollup || !regions.includes(selectedRegionRollup))) {
+    return [];
+  }
+
+  if (
+    homeDc &&
+    ((selectedServer.type === 'region' && selectedServer.region !== homeDc.region) ||
+      (selectedServer.type === 'dc' && selectedServer.dc.region !== homeDc.region))
+  ) {
+    return homeDc.worlds;
+  }
+
+  if (selectedServer.type === 'region') {
+    // Filter DCs and worlds to only show those from the currently selected region
+    const filteredDcs = selectedServer.region
+      ? dcs.filter((dc) => dc.region === selectedServer.region)
+      : [];
+
+    // Flatten all worlds from all data centers and sort them alphabetically
+    return filteredDcs.flatMap((dc) => dc.worlds).sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  const currentDc =
+    selectedServer.type === 'dc'
+      ? selectedServer.dc
+      : selectedServer.type === 'world'
+      ? dcs.find((dc) => dc.worlds.some((w) => w.id === selectedServer.world.id))
+      : undefined;
+  return currentDc?.worlds ?? homeDc?.worlds ?? dcs[0].worlds;
+};
+
 export default function MarketServerSelector({
   region,
   homeDc,
@@ -32,6 +79,7 @@ export default function MarketServerSelector({
   selectedServer,
   setSelectedServer,
 }: MarketServerSelectorProps) {
+  const filteredWorlds = getShownWorlds(selectedServer, [region], dcs, homeDc);
   return (
     <SimpleBar style={{ width: '100%' }}>
       <div className="item_nav_servers">
@@ -56,7 +104,7 @@ export default function MarketServerSelector({
             <i className="xiv-CrossWorld cw-summary"></i> {dc.name}
           </button>
         ))}
-        {(homeDc ?? dcs[0]).worlds.map((world, i) => {
+        {filteredWorlds.map((world, i) => {
           const homeWorld = world.name === homeWorldName;
           const icon = homeWorld ? 'xiv-ItemShard cw-home' : '';
           const className = homeWorld ? 'home-world' : '';
@@ -124,24 +172,15 @@ MarketServerSelector.Dynamic = function DynamicMarketServerSelector(
   props: DynamicMarketServerSelectorProps
 ) {
   const swrResult = useDataCenters(props.region);
-  const { data: dcs, error, isLoading } = swrResult;
-
-  // Debug logging - log everything
-  console.log('[MarketServerSelector.Dynamic] RENDER', {
-    region: props.region,
-    dcs: dcs,
-    dcsLength: dcs?.length,
-    error: error,
-    isLoading: isLoading,
-    swrKeys: Object.keys(swrResult),
-  });
+  const { data: dcs, error } = swrResult;
+  if (error) {
+    console.error(error);
+  }
 
   if (!dcs) {
-    console.log('[MarketServerSelector.Dynamic] returning skeleton');
     return <MarketServerSelector.Skeleton {...props} />;
   }
 
-  console.log('[MarketServerSelector.Dynamic] returning real component');
   return <MarketServerSelector {...props} dcs={dcs} />;
 };
 
@@ -158,8 +197,6 @@ MarketServerSelector.MultiRegion = function MultiRegionMarketServerSelector({
   setSelectedServer,
   homeWorldName,
 }: MultiRegionMarketServerSelectorProps) {
-  console.log('[MarketServerSelector.MultiRegion] RENDER', { regions });
-
   // Fetch data centers for all regions - we need to call hooks at the top level
   // Since regions array is limited to max 3 items (Japan, North-America, Europe, Oceania minus current),
   // we'll conditionally call hooks based on array length
@@ -167,27 +204,22 @@ MarketServerSelector.MultiRegion = function MultiRegionMarketServerSelector({
   const query1 = useDataCenters(regions[1] ?? regions[0]);
   const query2 = useDataCenters(regions[2] ?? regions[0]);
 
-  console.log('[MarketServerSelector.MultiRegion] queries', {
-    query0: { data: query0.data?.length, error: query0.error, isLoading: query0.isLoading },
-    query1: { data: query1.data?.length, error: query1.error, isLoading: query1.isLoading },
-    query2: { data: query2.data?.length, error: query2.error, isLoading: query2.isLoading },
-  });
-
   // Check if all necessary queries are loaded
   const allLoaded =
     query0.data !== undefined &&
     (regions.length < 2 || query1.data !== undefined) &&
     (regions.length < 3 || query2.data !== undefined);
 
-  console.log('[MarketServerSelector.MultiRegion] allLoaded:', allLoaded);
-
   if (!allLoaded) {
-    console.log('[MarketServerSelector.MultiRegion] returning skeleton');
     // Show skeleton for the first region while loading
-    return <MarketServerSelector.Skeleton region={regions[0]} selectedServer={selectedServer} setSelectedServer={setSelectedServer} />;
+    return (
+      <MarketServerSelector.Skeleton
+        region={regions[0]}
+        selectedServer={selectedServer}
+        setSelectedServer={setSelectedServer}
+      />
+    );
   }
-
-  console.log('[MarketServerSelector.MultiRegion] returning real component');
 
   // Combine all data centers from all regions
   const allDcs = [
@@ -210,9 +242,7 @@ MarketServerSelector.MultiRegion = function MultiRegionMarketServerSelector({
   const filteredDcs = currentSelectedRegion
     ? allDcs.filter((dc) => dc.region === currentSelectedRegion)
     : [];
-
-  // Flatten all worlds from all data centers and sort them alphabetically
-  const filteredWorlds = filteredDcs.flatMap((dc) => dc.worlds).sort((a, b) => a.name.localeCompare(b.name));
+  const filteredWorlds = getShownWorlds(selectedServer, regions, filteredDcs, undefined);
 
   return (
     <SimpleBar style={{ width: '100%' }}>

--- a/components/Market/MarketServerUpdateTimes/MarketServerUpdateTimes.tsx
+++ b/components/Market/MarketServerUpdateTimes/MarketServerUpdateTimes.tsx
@@ -2,22 +2,30 @@ import { t } from '@lingui/macro';
 import { Suspense } from 'react';
 import ago from 's-ago';
 import SimpleBar from 'simplebar-react';
+import { Server } from '../../../service/servers';
+import LinkButton from '../../LinkButton/LinkButton';
 
 interface MarketServerUpdateTimesProps {
   worlds: { id: number; name: string }[];
   worldUploadTimes: Record<number, number>;
+  setSelectedServer: (server: Server) => void;
 }
 
 export default function MarketServerUpdateTimes({
   worlds,
   worldUploadTimes,
+  setSelectedServer,
 }: MarketServerUpdateTimesProps) {
   return (
     <SimpleBar style={{ width: '100%' }}>
       <div className="market_update_times">
         {worlds.map((world) => (
           <div key={world.id}>
-            <h4>{world.name}</h4>
+            <h4>
+              <LinkButton onClick={() => setSelectedServer({ type: 'world', world })}>
+                {world.name}
+              </LinkButton>
+            </h4>
             <div>
               <Suspense>
                 {worldUploadTimes[world.id]

--- a/components/UniversalisLayout/components/SearchBar/SearchBar.tsx
+++ b/components/UniversalisLayout/components/SearchBar/SearchBar.tsx
@@ -1,6 +1,11 @@
 import { t, Trans } from '@lingui/macro';
 import { useRef, useState, useCallback } from 'react';
-import { SearchItem, searchItemsV1, searchItemsV2, searchItemsTc } from '../../../../service/search';
+import {
+  SearchItem,
+  searchItemsV1,
+  searchItemsV2,
+  searchItemsTc,
+} from '../../../../service/search';
 import useClickOutside from '../../../../hooks/useClickOutside';
 import useSettings from '../../../../hooks/useSettings';
 import debounce from 'lodash.debounce';

--- a/components/UniversalisLayout/components/SettingsModal/SettingsModal.tsx
+++ b/components/UniversalisLayout/components/SettingsModal/SettingsModal.tsx
@@ -223,7 +223,9 @@ export default function SettingsModal({ isOpen, closeModal, onSave }: SettingsMo
               </label>
               <div style={{ paddingBottom: 10 }}>
                 <small>
-                  <Trans>This will hide the decimal point and cents values in price displays.</Trans>
+                  <Trans>
+                    This will hide the decimal point and cents values in price displays.
+                  </Trans>
                 </small>
               </div>
               <div className="form">

--- a/hooks/useAlerts.ts
+++ b/hooks/useAlerts.ts
@@ -38,18 +38,20 @@ const DEMO_ALERTS: UserAlert[] = [
 export default function useAlerts() {
   const { isDemo } = useSession();
 
-  return useSWR(isDemo ? null : '/api/web/alerts', (url) =>
-    fetch(url)
-      .then(async (res) => {
-        if (!res.ok) {
-          const body = res.headers.get('Content-Type')?.includes('application/json')
-            ? (await res.json()).message
-            : await res.text();
-          throw new Error(body);
-        }
-        return await res.json();
-      })
-      .then((res) => res as UserAlert[]),
-    isDemo ? { fallbackData: DEMO_ALERTS } : undefined,
+  return useSWR(
+    isDemo ? null : '/api/web/alerts',
+    (url) =>
+      fetch(url)
+        .then(async (res) => {
+          if (!res.ok) {
+            const body = res.headers.get('Content-Type')?.includes('application/json')
+              ? (await res.json()).message
+              : await res.text();
+            throw new Error(body);
+          }
+          return await res.json();
+        })
+        .then((res) => res as UserAlert[]),
+    isDemo ? { fallbackData: DEMO_ALERTS } : undefined
   );
 }

--- a/hooks/useDataCenters.ts
+++ b/hooks/useDataCenters.ts
@@ -22,24 +22,33 @@ const getSortedServers = () =>
     });
 
 export default function useDataCenters(region?: string) {
-  return useSWR(`$servers-${region}`, () => {
-    console.log('[useDataCenters] fetching for region:', region);
-    return getSortedServers()
-      .then((servers) => {
-        const filtered = servers.filter((server) => !region || server.region === region);
-        console.log('[useDataCenters] filtered servers for region:', region, 'count:', filtered.length);
-        return filtered;
-      })
-      .catch((err) => {
-        console.error('[useDataCenters] error for region:', region, err);
-        throw err;
-      });
-  }, {
-    // Only revalidate when explicitly requested, not on focus/reconnect
-    revalidateOnFocus: false,
-    revalidateOnReconnect: false,
-    revalidateIfStale: false,
-    // Dedupe requests within 5 minutes
-    dedupingInterval: 300000,
-  });
+  return useSWR(
+    `$servers-${region}`,
+    () => {
+      console.log('[useDataCenters] fetching for region:', region);
+      return getSortedServers()
+        .then((servers) => {
+          const filtered = servers.filter((server) => !region || server.region === region);
+          console.log(
+            '[useDataCenters] filtered servers for region:',
+            region,
+            'count:',
+            filtered.length
+          );
+          return filtered;
+        })
+        .catch((err) => {
+          console.error('[useDataCenters] error for region:', region, err);
+          throw err;
+        });
+    },
+    {
+      // Only revalidate when explicitly requested, not on focus/reconnect
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      revalidateIfStale: false,
+      // Dedupe requests within 5 minutes
+      dedupingInterval: 300000,
+    }
+  );
 }

--- a/hooks/useSession.ts
+++ b/hooks/useSession.ts
@@ -16,8 +16,7 @@ import { useCookies } from 'react-cookie';
 export default function useSession() {
   const session = useNextAuthSession();
   const [cookies] = useCookies(['demo_loggedin']);
-  const isDemo =
-    process.env.NEXT_PUBLIC_ENABLE_DEMO === 'true' && cookies.demo_loggedin === 'yes';
+  const isDemo = process.env.NEXT_PUBLIC_ENABLE_DEMO === 'true' && cookies.demo_loggedin === 'yes';
 
   if (isDemo) {
     return {

--- a/hooks/useSettings.ts
+++ b/hooks/useSettings.ts
@@ -22,7 +22,9 @@ function validateLanguage(
   settings: Partial<Settings>,
   setSettings: (name: keyof Settings, value: any) => void
 ) {
-  if (!['ja', 'en', 'fr', 'de', 'chs', 'ko', 'tc'].includes(settings['mogboard_language'] ?? 'en')) {
+  if (
+    !['ja', 'en', 'fr', 'de', 'chs', 'ko', 'tc'].includes(settings['mogboard_language'] ?? 'en')
+  ) {
     setSettings('mogboard_language', '');
   }
 }

--- a/pages/api/web/alerts/index.ts
+++ b/pages/api/web/alerts/index.ts
@@ -28,7 +28,9 @@ class AlertsHandler {
       }
     } catch (err) {
       console.log('ALERT_CREATE_VALIDATE_ERROR: ' + String(err));
-      console.log('ALERT_CREATE_VALIDATE_STACK: ' + (err instanceof Error ? err.stack : 'no stack'));
+      console.log(
+        'ALERT_CREATE_VALIDATE_STACK: ' + (err instanceof Error ? err.stack : 'no stack')
+      );
       return res.status(500).json({ message: 'An error occurred.' });
     }
 

--- a/pages/market/[itemId].tsx
+++ b/pages/market/[itemId].tsx
@@ -41,6 +41,7 @@ interface StaticMarketsProps {
   homeDc: DataCenter;
   dcs: DataCenter[];
   selectedServer: Server;
+  setSelectedServer: (server: Server) => void;
   lang: Language;
 }
 
@@ -55,6 +56,7 @@ const StaticMarkets = ({
   homeDc,
   dcs,
   selectedServer,
+  setSelectedServer,
 }: StaticMarketsProps) => {
   return (
     <div className="tab">
@@ -75,6 +77,7 @@ const StaticMarkets = ({
               );
               return agg;
             }, {} as Record<string | number, number>)}
+            setSelectedServer={setSelectedServer}
           />
         </ErrorBoundary>
         <ErrorBoundary>
@@ -99,6 +102,7 @@ const StaticMarkets = ({
             <MarketServerUpdateTimes
               worlds={dc.worlds.sort((a, b) => a.name.localeCompare(b.name))}
               worldUploadTimes={markets[dc.name]?.worldUploadTimes ?? dc.worlds.map(() => 0)}
+              setSelectedServer={setSelectedServer}
             />
           </ErrorBoundary>
           <ErrorBoundary>
@@ -140,13 +144,20 @@ interface DynamicMarketsProps {
   item: Item;
   region: string;
   selectedServer: Server;
+  setSelectedServer: (server: Server) => void;
   lang: Language;
 }
 
 /**
  * Market data on-demand.
  */
-const DynamicMarkets = ({ item, selectedServer, region, lang }: DynamicMarketsProps) => {
+const DynamicMarkets = ({
+  item,
+  selectedServer,
+  setSelectedServer,
+  region,
+  lang,
+}: DynamicMarketsProps) => {
   const { data: market } = useRegionMarket(region, item.id);
   const { data: dcs } = useDataCenters(region);
 
@@ -166,6 +177,18 @@ const DynamicMarkets = ({ item, selectedServer, region, lang }: DynamicMarketsPr
     [market]
   );
 
+  // World views only require world-level data, so they render independently
+  // of region-level market and data center requests.
+  if (selectedServer.type === 'world') {
+    return (
+      <div className="tab-page tab-summary open">
+        <ErrorBoundary>
+          <MarketWorld.Dynamic item={item} world={selectedServer.world} lang={lang} open />
+        </ErrorBoundary>
+      </div>
+    );
+  }
+
   if (!market || !dcs) {
     return (
       <div className="tab-page tab-summary open">
@@ -180,7 +203,11 @@ const DynamicMarkets = ({ item, selectedServer, region, lang }: DynamicMarketsPr
         <div className="tab">
           <div className="tab-page tab-summary open">
             <ErrorBoundary>
-              <MarketRegionUpdateTimes dcs={dcs} worldUploadTimes={getWorldUploadTimes()} />
+              <MarketRegionUpdateTimes
+                dcs={dcs}
+                worldUploadTimes={getWorldUploadTimes()}
+                setSelectedServer={setSelectedServer}
+              />
             </ErrorBoundary>
             <ErrorBoundary>
               <MarketRegion.Dynamic item={item} region={region} dcs={dcs} lang={lang} open />
@@ -197,21 +224,13 @@ const DynamicMarkets = ({ item, selectedServer, region, lang }: DynamicMarketsPr
               <MarketServerUpdateTimes
                 worlds={dc.worlds.sort((a, b) => a.name.localeCompare(b.name))}
                 worldUploadTimes={getWorldUploadTimes(dc)}
+                setSelectedServer={setSelectedServer}
               />
             </ErrorBoundary>
             <ErrorBoundary>
               <MarketDataCenter.Dynamic item={item} dc={dc} lang={lang} open />
             </ErrorBoundary>
           </div>
-        </div>
-      );
-    case 'world':
-      const { world } = selectedServer;
-      return (
-        <div className="tab-page tab-summary open">
-          <ErrorBoundary>
-            <MarketWorld.Dynamic item={item} world={world} lang={lang} open />
-          </ErrorBoundary>
         </div>
       );
   }
@@ -224,11 +243,18 @@ interface MarketsProps {
   homeDc: DataCenter;
   dcs: DataCenter[];
   selectedServer: Server;
+  setSelectedServer: (server: Server) => void;
   lang: Language;
 }
 
 const Markets = (props: MarketsProps) => {
-  if (props.markets !== undefined) {
+  // Render the data we already hydrated if we hydrated it; otherwise use the dynamic component because
+  // we didn't hydrate it and need to fetch the data dynamically.
+  if (
+    props.markets !== undefined &&
+    props.selectedServer.type === 'dc' &&
+    props.markets[props.selectedServer.dc.name] !== undefined
+  ) {
     const markets = props.markets; // Help TS out a bit
     return <StaticMarkets {...props} markets={markets} />;
   } else {
@@ -333,6 +359,24 @@ const Market: NextPage<MarketProps> = ({
     }
   }, lists);
 
+  // This gets special treatment, and isn't loaded into the page by default.
+  // Typically, all data is loaded ahead of time to support scrapers/sheets,
+  // but for this part of the UI we're not bound to that decision.
+  const [dynamicServer, setDynamicServerBase] = useState<Server | null>(null);
+  const [dynamicRegion, setDynamicRegion] = useState<Region | null>(null);
+
+  const setDynamicServer = useCallback((s: Server | null) => {
+    if (s == null) {
+      setDynamicRegion(null);
+    } else if (s.type === 'region') {
+      setDynamicRegion(s.region);
+    } else if (s.type === 'dc') {
+      setDynamicRegion(s.dc.region);
+    }
+    // World selections retain the region of the surrounding dynamic context.
+    setDynamicServerBase(s);
+  }, []);
+
   const selectServer = useCallback(
     (s: Server) => {
       // Set the new last-selected server for future page loads
@@ -347,13 +391,22 @@ const Market: NextPage<MarketProps> = ({
       setDynamicServer(null);
       setSelectedServer(s);
     },
-    [setLastSelectedServer]
+    [setLastSelectedServer, setDynamicServer]
   );
 
-  // This gets special treatment, and isn't loaded into the page by default.
-  // Typically, all data is loaded ahead of time to support scrapers/sheets,
-  // but for this part of the UI we're not bound to that decision.
-  const [dynamicServer, setDynamicServer] = useState<Server | null>(null);
+  // Selections made within the dynamic view (e.g. the update-time world
+  // links) replace the dynamic selection, preserving the external
+  // region/data center context instead of resetting to the home region.
+  const selectDynamicServer = useCallback(
+    (s: Server) => {
+      if (dynamicServer != null) {
+        setDynamicServer(s);
+      } else {
+        selectServer(s);
+      }
+    },
+    [dynamicServer, selectServer, setDynamicServer]
+  );
 
   const item = getItem(itemId, lang);
 
@@ -424,17 +477,12 @@ const Market: NextPage<MarketProps> = ({
           </div>
           <Markets
             item={item}
-            region={
-              dynamicServer && dynamicServer.type === 'region'
-                ? dynamicServer.region
-                : dynamicServer && dynamicServer.type === 'dc'
-                ? dynamicServer.dc.region
-                : region
-            }
+            region={dynamicRegion ?? region}
             markets={dynamicServer ? undefined : markets}
             homeDc={homeDc}
             dcs={dcs}
             selectedServer={dynamicServer ?? selectedServer}
+            setSelectedServer={selectDynamicServer}
             lang={lang}
           />
         </div>

--- a/service/search.ts
+++ b/service/search.ts
@@ -150,15 +150,15 @@ export async function searchItemsTc(
   lang: string,
   abort?: AbortController
 ): Promise<ItemSearchResults> {
-  const params = new URLSearchParams({  
-    sheets: 'Items',  
-    query: query,  
-    language: lang,  
-    limit: '100',  
-    field: 'Name,ItemSearchCategory.Name,Icon,LevelItem.todo,Rarity',  
-  });  
+  const params = new URLSearchParams({
+    sheets: 'Items',
+    query: query,
+    language: lang,
+    limit: '100',
+    field: 'Name,ItemSearchCategory.Name,Icon,LevelItem.todo,Rarity',
+  });
 
-  const searchUrl = `https://tc-ffxiv-item-search-service.onrender.com/items/search?${params.toString()}`;  
+  const searchUrl = `https://tc-ffxiv-item-search-service.onrender.com/items/search?${params.toString()}`;
   const data = await fetch(searchUrl, {
     signal: abort?.signal,
   })
@@ -188,7 +188,7 @@ export async function searchItemsTc(
         rarity: result.rarity,
       }))
       .sort((a, b) => b.levelItem - a.levelItem),
-  }
+  };
 }
 
 function iconUrlV2(icon: BoilmasterIcon): string {


### PR DESCRIPTION
Adds support for navigating to a world's listings via its label in the update time bar, and also tweak the semantics around what worlds get placed in the server selector to acommodate that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * World names in market update views are now clickable, allowing faster server selection.
  * Market views dynamically display worlds relevant to the selected region and data center.
  * Added consistent link-style button interactions with visible keyboard focus states.

* **Bug Fixes**
  * Improved market data selection so stale or mismatched hydrated data is not displayed.
  * Preserved loading fallbacks while improving handling of dynamic data-fetching errors.

* **Style**
  * Standardized formatting across search, settings, hooks, alerts, and session-related code without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->